### PR TITLE
ARC-1414 Add isAdmin check at the start of every resolver func

### DIFF
--- a/app/manifest.yml
+++ b/app/manifest.yml
@@ -51,3 +51,4 @@ permissions:
     - 'delete:build-info:jira'
     - 'write:deployment-info:jira'
     - 'delete:deployment-info:jira'
+    - 'read:permission:jira'

--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@forge/api": "2.6.0",
-    "@forge/bridge": "^2.4.0",
     "@forge/resolver": "1.4.2",
     "jsonwebtoken": "8.5.1"
   },

--- a/app/src/check-permissions.ts
+++ b/app/src/check-permissions.ts
@@ -1,0 +1,30 @@
+import api, { route } from '@forge/api';
+
+const isAdmin = async (accountId: any): Promise<boolean> => {
+	const permissionRequestBody = `{
+      "globalPermissions": [
+        "ADMINISTER"
+      ],
+      "accountId": "${accountId}"
+    }`;
+
+	const permissions = await api.asApp().requestJira(route`/rest/api/3/permissions/check`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json'
+		},
+		body: permissionRequestBody
+	});
+
+	if (permissions.status === 403) {
+		return false;
+	}
+
+	const permissionDetails = await permissions.json();
+	return permissionDetails?.globalPermissions?.includes('ADMINISTER');
+};
+
+export {
+	isAdmin
+};

--- a/app/src/check-permissions.ts
+++ b/app/src/check-permissions.ts
@@ -21,12 +21,12 @@ export const adminPermissionCheck = async (req: any): Promise<void> => {
 	});
 
 	if (permissions.status === 403) {
-		throw new Error('Only Jira administrators can perform this operation.');
+		throw new Error('Only Jira administrators can access the Jenkins for Jira admin page.');
 	}
 
 	const permissionDetails = await permissions.json();
 
 	if (!permissionDetails?.globalPermissions?.includes('ADMINISTER')) {
-		throw new Error('Only Jira administrators can perform this operation.');
+		throw new Error('Only Jira administrators can access the Jenkins for Jira admin page.');
 	}
 };

--- a/app/src/check-permissions.ts
+++ b/app/src/check-permissions.ts
@@ -2,11 +2,11 @@ import api, { route } from '@forge/api';
 
 const isAdmin = async (accountId: any): Promise<boolean> => {
 	const permissionRequestBody = `{
-      "globalPermissions": [
-        "ADMINISTER"
-      ],
-      "accountId": "${accountId}"
-    }`;
+		"globalPermissions": [
+			"ADMINISTER"
+		],
+		"accountId": "${accountId}"
+	}`;
 
 	const permissions = await api.asApp().requestJira(route`/rest/api/3/permissions/check`, {
 		method: 'POST',

--- a/app/src/resolvers.ts
+++ b/app/src/resolvers.ts
@@ -8,49 +8,42 @@ import { getJenkinsServerWithSecret } from './storage/get-jenkins-server-with-se
 import { updateJenkinsServer } from './storage/update-jenkins-server';
 import { deleteBuilds } from './jira-client/delete-builds';
 import { deleteDeployments } from './jira-client/delete-deployments';
-import { isAdmin } from './check-permissions';
+import { adminPermissionCheck } from './check-permissions';
 
 const resolver = new Resolver();
 
-const checkPermissions = async (accountId: string) => {
-	const admin = await isAdmin(accountId);
-	if (!admin) {
-		throw new Error('Only Jira administrators can perform this operation.');
-	}
-};
-
 resolver.define('fetchJenkinsEventHandlerUrl', async (req) => {
-	await checkPermissions(req.context.accountId);
+	await adminPermissionCheck(req);
 	return {
 		url: await webTrigger.getUrl('jenkins-webtrigger')
 	};
 });
 
 resolver.define('connectJenkinsServer', async (req) => {
-	await checkPermissions(req.context.accountId);
+	await adminPermissionCheck(req);
 	const payload = req.payload as JenkinsServer;
 	return connectJenkinsServer(payload);
 });
 
 resolver.define('updateJenkinsServer', async (req) => {
-	await checkPermissions(req.context.accountId);
+	await adminPermissionCheck(req);
 	const payload = req.payload as JenkinsServer;
 	return updateJenkinsServer(payload);
 });
 
 resolver.define('getAllJenkinsServers', async (req) => {
-	await checkPermissions(req.context.accountId);
+	await adminPermissionCheck(req);
 	return getAllJenkinsServers();
 });
 
 resolver.define('getJenkinsServerWithSecret', async (req) => {
-	await checkPermissions(req.context.accountId);
+	await adminPermissionCheck(req);
 	const jenkinsServerUuid = req.payload.uuid as string;
 	return getJenkinsServerWithSecret(jenkinsServerUuid);
 });
 
 resolver.define('disconnectJenkinsServer', async (req) => {
-	await checkPermissions(req.context.accountId);
+	await adminPermissionCheck(req);
 	const { cloudId } = req.context;
 	const jenkinsServerUuid = req.payload.uuid;
 	return Promise.all([

--- a/app/src/resolvers.ts
+++ b/app/src/resolvers.ts
@@ -8,31 +8,49 @@ import { getJenkinsServerWithSecret } from './storage/get-jenkins-server-with-se
 import { updateJenkinsServer } from './storage/update-jenkins-server';
 import { deleteBuilds } from './jira-client/delete-builds';
 import { deleteDeployments } from './jira-client/delete-deployments';
+import { isAdmin } from './check-permissions';
 
 const resolver = new Resolver();
 
-resolver.define('fetchJenkinsEventHandlerUrl', async () => ({
-	url: await webTrigger.getUrl('jenkins-webtrigger')
-}));
+const checkPermissions = async (accountId: string) => {
+	const admin = await isAdmin(accountId);
+	if (!admin) {
+		throw new Error('Only Jira administrators can perform this operation.');
+	}
+};
+
+resolver.define('fetchJenkinsEventHandlerUrl', async (req) => {
+	await checkPermissions(req.context.accountId);
+	return {
+		url: await webTrigger.getUrl('jenkins-webtrigger')
+	};
+});
 
 resolver.define('connectJenkinsServer', async (req) => {
+	await checkPermissions(req.context.accountId);
 	const payload = req.payload as JenkinsServer;
 	return connectJenkinsServer(payload);
 });
 
 resolver.define('updateJenkinsServer', async (req) => {
+	await checkPermissions(req.context.accountId);
 	const payload = req.payload as JenkinsServer;
 	return updateJenkinsServer(payload);
 });
 
-resolver.define('getAllJenkinsServers', async () => getAllJenkinsServers());
+resolver.define('getAllJenkinsServers', async (req) => {
+	await checkPermissions(req.context.accountId);
+	return getAllJenkinsServers();
+});
 
 resolver.define('getJenkinsServerWithSecret', async (req) => {
+	await checkPermissions(req.context.accountId);
 	const jenkinsServerUuid = req.payload.uuid as string;
 	return getJenkinsServerWithSecret(jenkinsServerUuid);
 });
 
 resolver.define('disconnectJenkinsServer', async (req) => {
+	await checkPermissions(req.context.accountId);
 	const { cloudId } = req.context;
 	const jenkinsServerUuid = req.payload.uuid;
 	return Promise.all([

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -316,13 +316,6 @@
   dependencies:
     tslib "^1.11.0"
 
-"@forge/bridge@^2.4.0":
-  version "2.4.0"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/@forge/bridge/-/bridge-2.4.0.tgz#6542a1bd5ad400002254a5cf755850fbcec55cee"
-  integrity sha512-ySILbSdJsCPLwQyL+ctZADo8EVjQXya0gjKMUmXSTlts9SgL5W4QgmT8ac1ZWxUDpvhGsaC7txQIsOWRzqAlSA==
-  dependencies:
-    "@types/history" "^4.7.8"
-
 "@forge/resolver@1.4.2":
   version "1.4.2"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/@forge/resolver/-/resolver-1.4.2.tgz#2fbdf3894c1a4a2c96d7e0dedb64bfd5eaa0dbd7"
@@ -653,11 +646,6 @@
   integrity sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
   dependencies:
     "@types/node" "*"
-
-"@types/history@^4.7.8":
-  version "4.7.11"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
-  integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"


### PR DESCRIPTION
Add permission check before every resolver func so that only administrators can access these methods.

If user is not an admin, they will see an error on the console, or an infinitely loading web page (they should not be able to access the app UI unless they are an admin, so this is not an issue)

<img width="841" alt="Screen Shot 2022-06-29 at 12 38 05 pm" src="https://user-images.githubusercontent.com/28718897/176339677-f3a51ba5-41cc-4318-bfd2-08672dfe4b12.png">

<img width="1792" alt="Screen Shot 2022-06-29 at 12 37 59 pm" src="https://user-images.githubusercontent.com/28718897/176339665-bbf580d6-f148-4ef0-8c6d-9da0ca6cdb69.png">
