### PR TITLE
ARC-1584 Update ConfigurationSteps component to have 3 steps

### DIFF
--- a/app/jenkins-for-jira-ui/src/components/ConnectJenkins/ConfigurationSteps/ConfigurationSteps.test.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectJenkins/ConfigurationSteps/ConfigurationSteps.test.tsx
@@ -3,18 +3,47 @@ import { render, screen } from '@testing-library/react';
 
 import { ConfigurationSteps } from './ConfigurationSteps';
 
+// Note: Using getByText() in this test as AtlasKit does not give you the ability to attach a testId to the elements.
+
 describe('ConfigurationSteps Page Suite', () => {
-	it('Should render two stages', () => {
+	it('Should render three stages', () => {
 		render(<ConfigurationSteps currentStage="install" />);
 		expect(screen.getByText('Install plugin')).toBeInTheDocument();
-		expect(screen.getByText('Connect your app')).toBeInTheDocument();
+		expect(screen.getByText('Create server')).toBeInTheDocument();
+		expect(screen.getByText('Connect server')).toBeInTheDocument();
 	});
 
 	it('Should render correctly with install as currentStage', () => {
 		render(<ConfigurationSteps currentStage="install" />);
 		const InstallJenkinsStep = screen.getByText('Install plugin');
-		const ConnectJenkinsStep = screen.getByText('Connect your app');
+		const CreateServerStep = screen.getByText('Create server');
+		const ConnectServerStep = screen.getByText('Connect server');
 		expect(InstallJenkinsStep).toHaveAttribute('style', 'color: rgb(0, 101, 255); font-weight: 600;');
-		expect(ConnectJenkinsStep).toHaveAttribute('style', 'color: rgb(94, 108, 132); font-weight: 400;');
+		expect(CreateServerStep).toHaveAttribute('style', 'color: rgb(94, 108, 132); font-weight: 400;');
+		expect(ConnectServerStep).toHaveAttribute('style', 'color: rgb(94, 108, 132); font-weight: 400;');
+	});
+
+	it('Should render correctly with create as currentStage', () => {
+		render(<ConfigurationSteps currentStage="create" />);
+		const InstallJenkinsStepParentContainer = screen.getByText('Install plugin').closest('div');
+		const CreateServerStep = screen.getByText('Create server');
+		const ConnectServerStep = screen.getByText('Connect server');
+
+		// Visited steps are styled via parent container
+		expect(InstallJenkinsStepParentContainer).toHaveAttribute('style', 'color: rgb(23, 43, 77); font-weight: 600;');
+		expect(CreateServerStep).toHaveAttribute('style', 'color: rgb(0, 101, 255); font-weight: 600;');
+		expect(ConnectServerStep).toHaveAttribute('style', 'color: rgb(94, 108, 132); font-weight: 400;');
+	});
+
+	it('Should render correctly with connect as currentStage', () => {
+		render(<ConfigurationSteps currentStage="connect" />);
+		const InstallJenkinsStepParentContainer = screen.getByText('Install plugin').closest('div');
+		const CreateServerStepParentContainer = screen.getByText('Create server').closest('div');
+		const ConnectServerStep = screen.getByText('Connect server');
+
+		// Visited steps are styled via parent container
+		expect(InstallJenkinsStepParentContainer).toHaveAttribute('style', 'color: rgb(23, 43, 77); font-weight: 600;');
+		expect(CreateServerStepParentContainer).toHaveAttribute('style', 'color: rgb(23, 43, 77); font-weight: 600;');
+		expect(ConnectServerStep).toHaveAttribute('style', 'color: rgb(0, 101, 255); font-weight: 600;');
 	});
 });

--- a/app/jenkins-for-jira-ui/src/components/ConnectJenkins/ConfigurationSteps/ConfigurationSteps.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectJenkins/ConfigurationSteps/ConfigurationSteps.tsx
@@ -22,7 +22,7 @@ const ConfigurationSteps = ({ currentStage }: AppProps) => {
 				percentageComplete: 0,
 				status: 'current',
 				href: '#',
-				onClick: () => { history.push('/install'); }
+				onClick: () => history.push('/install')
 			},
 			{
 				id: 'create',
@@ -46,7 +46,7 @@ const ConfigurationSteps = ({ currentStage }: AppProps) => {
 				percentageComplete: 100,
 				status: 'visited',
 				href: '#',
-				onClick: () => { history.push('/install'); }
+				onClick: () => history.push('/install')
 			},
 			{
 				id: 'create',
@@ -54,7 +54,7 @@ const ConfigurationSteps = ({ currentStage }: AppProps) => {
 				percentageComplete: 0,
 				status: 'current',
 				href: '#',
-				onClick: () => { history.push('/create'); }
+				onClick: () => history.push('/create')
 			},
 			{
 				id: 'connect',
@@ -71,7 +71,7 @@ const ConfigurationSteps = ({ currentStage }: AppProps) => {
 				percentageComplete: 100,
 				status: 'visited',
 				href: '#',
-				onClick: () => { history.push('/install'); }
+				onClick: () => history.push('/install')
 			},
 			{
 				id: 'create',
@@ -79,7 +79,7 @@ const ConfigurationSteps = ({ currentStage }: AppProps) => {
 				percentageComplete: 100,
 				status: 'visited',
 				href: '#',
-				onClick: () => { history.push('/create'); }
+				onClick: () => history.push('/create')
 			},
 			{
 				id: 'connect',

--- a/app/jenkins-for-jira-ui/src/components/ConnectJenkins/ConfigurationSteps/ConfigurationSteps.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectJenkins/ConfigurationSteps/ConfigurationSteps.tsx
@@ -14,36 +14,86 @@ type AppProps = {
 const ConfigurationSteps = ({ currentStage }: AppProps) => {
 	const history = useHistory();
 
-	const stages: Stages = [
-		{
-			id: 'install',
-			label: 'Install plugin',
-			percentageComplete:
-				currentStage === 'install'
-					? 0
-					: 100,
-			status:
-				currentStage === 'install'
-					? 'current'
-					: 'visited',
-			href: '#',
-			onClick: () => { history.push('/install'); }
-		},
-		{
-			id: 'connect',
-			label: 'Connect your app',
-			percentageComplete: 0,
-			status:
-				currentStage === 'connect'
-					? 'current'
-					: 'unvisited',
-			href: '#'
-		}
-	];
+	const stages: { [key: string]: Stages } = {
+		install: [
+			{
+				id: 'install',
+				label: 'Install plugin',
+				percentageComplete: 0,
+				status: 'current',
+				href: '#',
+				onClick: () => { history.push('/install'); }
+			},
+			{
+				id: 'create',
+				label: 'Create server',
+				percentageComplete: 0,
+				status: 'unvisited',
+				href: '#'
+			},
+			{
+				id: 'connect',
+				label: 'Connect server',
+				percentageComplete: 0,
+				status: 'unvisited',
+				href: '#'
+			}
+		],
+		create: [
+			{
+				id: 'install',
+				label: 'Install plugin',
+				percentageComplete: 100,
+				status: 'visited',
+				href: '#',
+				onClick: () => { history.push('/install'); }
+			},
+			{
+				id: 'create',
+				label: 'Create server',
+				percentageComplete: 0,
+				status: 'current',
+				href: '#',
+				onClick: () => { history.push('/create'); }
+			},
+			{
+				id: 'connect',
+				label: 'Connect server',
+				percentageComplete: 0,
+				status: 'unvisited',
+				href: '#'
+			}
+		],
+		connect: [
+			{
+				id: 'install',
+				label: 'Install plugin',
+				percentageComplete: 100,
+				status: 'visited',
+				href: '#',
+				onClick: () => { history.push('/install'); }
+			},
+			{
+				id: 'create',
+				label: 'Create server',
+				percentageComplete: 100,
+				status: 'visited',
+				href: '#',
+				onClick: () => { history.push('/create'); }
+			},
+			{
+				id: 'connect',
+				label: 'Connect server',
+				percentageComplete: 0,
+				status: 'current',
+				href: '#'
+			}
+		]
+	};
 
 	return (
 		<div className={progressTrackerContainer}>
-			<ProgressTracker items={stages} />
+			<ProgressTracker items={stages[currentStage]} />
 		</div>
 	);
 };


### PR DESCRIPTION
**Context**
Due to a confusing Jenkins server connection flow, we have decided to split the Jenkins server connection flow into 3 steps. For more information, [see here](https://hello.atlassian.net/wiki/spaces/PF/pages/1793379128/JFA+ARC-1264+-+Split+Connection+Screen+plan+and+ideation).

**Changes in this PR**
We are splitting the server connection screen and need to update the progress tracker to include 3 steps. This PR leverages the AtlasKit [Progress Tracker](https://atlassian.design/components/progress-tracker/examples) to create a progress tracker that takes you through connecting a Jenkins server to your Jira. The `ConfigurationSteps` component takes in a `currentStage` prop and returns the progress tracker at the appropriate stage.

**From 2 steps:**
<img width="250" alt="image" src="https://user-images.githubusercontent.com/28718897/180919775-ac71b986-5f3a-4a41-ab1f-e4f5f169b46b.png">


**To 3 steps:**
On install step:
<img width="278" alt="Screen Shot 2022-07-26 at 1 32 44 pm" src="https://user-images.githubusercontent.com/28718897/180919703-c3219765-a3ac-4ba8-bc25-23608ebba1b2.png">

On create step:
<img width="313" alt="Screen Shot 2022-07-26 at 1 32 39 pm" src="https://user-images.githubusercontent.com/28718897/180919696-987c1e19-7736-415e-bbc3-9518cdc7b786.png">

On connect step:
<img width="279" alt="Screen Shot 2022-07-26 at 1 32 57 pm" src="https://user-images.githubusercontent.com/28718897/180919706-8b950292-c18b-4017-aa94-707478416a23.png">


**To be completed:**
- Connecting this component to the Jenkins server connection flow screens