### PR TITLE
ARC-1264 Add create server step to server connection flow

### DIFF
--- a/app/jenkins-for-jira-ui/src/App.tsx
+++ b/app/jenkins-for-jira-ui/src/App.tsx
@@ -13,6 +13,7 @@ import { ManageConnection } from './components/ManageConnection/ManageConnection
 import { spinnerHeight } from './common/styles/spinner.styles';
 import { JenkinsSpinner } from './components/JenkinsSpinner/JenkinsSpinner';
 import { PendingDeploymentState } from './components/JenkinsServerList/PendingDeploymentState/PendingDeploymentState';
+import { CreateServer } from './components/ConnectJenkins/CreateServer/CreateServer';
 
 const AppContainer = styled.div`
 	color: #172B4D;
@@ -38,6 +39,9 @@ const App = () => {
 						</Route>
 						<Route path="/install">
 							<InstallJenkins />
+						</Route>
+						<Route path="/create">
+							<CreateServer />
 						</Route>
 						<Route path="/connect">
 							<ConnectJenkins />

--- a/app/jenkins-for-jira-ui/src/components/ConnectJenkins/CreateServer/CreateServer.test.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectJenkins/CreateServer/CreateServer.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {
+	fireEvent,
+	render,
+	waitFor
+} from '@testing-library/react';
+import { CreateServer } from './CreateServer';
+
+describe('CreateServer component', () => {
+	it('Should render form with Jenkins server name text field', async () => {
+		const { getByTestId } = render(
+			<CreateServer />
+		);
+
+		expect(getByTestId('server-name')).toBeInTheDocument();
+	});
+
+	it('should render Next button if isLoading is false', async () => {
+		const { getByTestId } = render(
+			<CreateServer />
+		);
+
+		expect(getByTestId('submit-button')).toBeInTheDocument();
+	});
+
+	it('should render LoadingButton is isLoading is true', async () => {
+		const { getByTestId } = render(
+			<CreateServer />
+		);
+		// Input server name into text field and submit
+		fireEvent.change(getByTestId('server-name'), { target: { value: 'Server name' } });
+		fireEvent.click(getByTestId('submit-button'));
+
+		await waitFor(() => {
+			expect(getByTestId('loading-button')).toBeInTheDocument();
+		});
+	});
+});

--- a/app/jenkins-for-jira-ui/src/components/ConnectJenkins/CreateServer/CreateServer.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectJenkins/CreateServer/CreateServer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import Button, { LoadingButton } from '@atlaskit/button';
 import Form, {
 	FormFooter
@@ -18,28 +18,20 @@ import { ConnectLogos } from '../ConnectLogos/ConnectLogos';
 
 const CreateServer = () => {
 	const history = useHistory();
-	const [uuid] = useState(uuidv4);
 	const [serverName, setServerName] = useState('');
-	const [secret, setSecret] = useState('');
 	const [hasError, setHasError] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
 	const [errorMessage, setErrorMessage] = useState('');
 
-	useEffect(() => {
-		setSecret(generateNewSecret());
-	}, [uuid]);
-
-	const createServer = async () => {
-		const isValidForm = isFormValid(serverName, setHasError, setErrorMessage);
-
-		if (isValidForm) {
+	const onSubmitCreateServer = async () => {
+		if (isFormValid(serverName, setHasError, setErrorMessage)) {
 			setIsLoading(true);
 
 			try {
 				await createJenkinsServer({
 					name: serverName,
-					uuid,
-					secret,
+					uuid: uuidv4(),
+					secret: generateNewSecret(),
 					pipelines: []
 				});
 				history.push('/connect');
@@ -57,7 +49,7 @@ const CreateServer = () => {
 
 			<StyledH1>Create your Jenkins Server</StyledH1>
 			<StyledInstallationContent>
-				<Form onSubmit={createServer}>
+				<Form onSubmit={onSubmitCreateServer}>
 					{({ formProps }: any) => (
 						<form {...formProps} name='create-server-form' data-testid="createServerForm">
 							<ServerConfigurationFormName

--- a/app/jenkins-for-jira-ui/src/components/ConnectJenkins/CreateServer/CreateServer.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectJenkins/CreateServer/CreateServer.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import Button, { LoadingButton } from '@atlaskit/button';
+import Form, {
+	FormFooter
+} from '@atlaskit/form';
+import { v4 as uuidv4 } from 'uuid';
+import { useHistory } from 'react-router';
+import {
+	loadingIcon
+} from '../../JenkinsConfigurationForm/JenkinsConfigurationForm.styles';
+import { createJenkinsServer } from '../../../api/createJenkinsServer';
+import { ConfigurationSteps } from '../ConfigurationSteps/ConfigurationSteps';
+import { StyledH1, StyledInstallationContainer, StyledInstallationContent } from '../ConnectJenkins.styles';
+import { generateNewSecret } from '../../JenkinsConfigurationForm/JenkinsConfigurationForm';
+import { isFormValid, setName } from '../../../common/util/jenkinsConnectionsUtils';
+import { ServerConfigurationFormName } from '../../JenkinsConfigurationForm/ServerConfigurationFormElements/ServerConfigurationFormName/ServerConfigurationFormName';
+import { ConnectLogos } from '../ConnectLogos/ConnectLogos';
+
+const CreateServer = () => {
+	const history = useHistory();
+	const [uuid] = useState(uuidv4);
+	const [serverName, setServerName] = useState('');
+	const [secret, setSecret] = useState('');
+	const [hasError, setHasError] = useState(false);
+	const [isLoading, setIsLoading] = useState(false);
+	const [errorMessage, setErrorMessage] = useState('');
+
+	useEffect(() => {
+		setSecret(generateNewSecret());
+	}, [uuid]);
+
+	const createServer = async () => {
+		const isValidForm = isFormValid(serverName, setHasError, setErrorMessage);
+
+		if (isValidForm) {
+			setIsLoading(true);
+
+			try {
+				await createJenkinsServer({
+					name: serverName,
+					uuid,
+					secret,
+					pipelines: []
+				});
+				history.push('/connect');
+			} catch (e) {
+				console.error('Error: ', e);
+				setIsLoading(false);
+			}
+		}
+	};
+
+	return (
+		<StyledInstallationContainer>
+			<ConfigurationSteps currentStage={'create'} />
+			<ConnectLogos />
+
+			<StyledH1>Create your Jenkins Server</StyledH1>
+			<StyledInstallationContent>
+				<Form onSubmit={createServer}>
+					{({ formProps }: any) => (
+						<form {...formProps} name='create-server-form' data-testid="createServerForm">
+							<ServerConfigurationFormName
+								serverName={serverName}
+								setServerName={(event: React.ChangeEvent<HTMLInputElement>) =>
+									setName(event, setServerName)
+								}
+								hasError={hasError}
+								errorMessage={errorMessage}
+								setHasError={setHasError}
+							/>
+
+							<FormFooter>
+								{isLoading
+									? <LoadingButton appearance='primary' isLoading className={loadingIcon} testId='loading-button' />
+									:	<Button type='submit' appearance='primary' testId='submit-button'>
+										Next
+									</Button>
+								}
+							</FormFooter>
+						</form>
+					)}
+				</Form>
+			</StyledInstallationContent>
+		</StyledInstallationContainer>
+	);
+};
+
+export {
+	CreateServer
+};

--- a/app/jenkins-for-jira-ui/src/components/ConnectJenkins/InstallJenkins/InstallJenkins.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectJenkins/InstallJenkins/InstallJenkins.tsx
@@ -15,7 +15,7 @@ const InstallJenkins = () => {
 	const history = useHistory();
 
 	const onClickNext = () => {
-		history.push('/connect');
+		history.push('/create');
 	};
 
 	return (

--- a/app/jenkins-for-jira-ui/src/components/JenkinsConfigurationForm/ServerConfigurationFormElements/ServerConfigurationFormName/ServerConfigurationFormName.tsx
+++ b/app/jenkins-for-jira-ui/src/components/JenkinsConfigurationForm/ServerConfigurationFormElements/ServerConfigurationFormName/ServerConfigurationFormName.tsx
@@ -28,7 +28,7 @@ const ServerConfigurationFormName = ({
 	return (
 		<Fragment>
 			<StyledInputHeaderContainer>
-				<h3>Jenkins server</h3>
+				<h3>Jenkins server name</h3>
 				<FormTooltip
 					content='Create a display name for your Jenkins server.'
 					label='Jenkins Server'


### PR DESCRIPTION
**Context**
Due to a confusing Jenkins server connection flow, we have decided to split the Jenkins server connection flow into 3 steps. For more information, [see here](https://hello.atlassian.net/wiki/spaces/PF/pages/1793379128/JFA+ARC-1264+-+Split+Connection+Screen+plan+and+ideation).

**Changes in this PR**
This PR adds a `CreateServer` component that allows the customer to create a Jenkins Server with the name of their choice. When you press "Next", the button will switch into a loading state and create the server. It will then move on to the "Connect Jenkins" screen.

Error state
<img width="707" alt="Screen Shot 2022-07-26 at 4 38 18 pm" src="https://user-images.githubusercontent.com/28718897/180958175-334e7155-16e2-4d46-ac34-41229a7715c3.png">

Loading state
<img width="750" alt="Screen Shot 2022-07-26 at 4 38 28 pm" src="https://user-images.githubusercontent.com/28718897/180958208-3f75426c-1c33-4288-b387-3b251b867383.png">


**Tasks to be completed**
Currently, when you move on to the "Connect Jenkins" screen, your server details are not passed through. This means that the second screen will just create a new server. This will be addressed in an upcoming PR.