### PR TITLE
ARC-1264 Update ConnectJenkins component to take in and display connected server details

### DIFF
--- a/app/jenkins-for-jira-ui/src/App.tsx
+++ b/app/jenkins-for-jira-ui/src/App.tsx
@@ -43,7 +43,7 @@ const App = () => {
 						<Route path="/create">
 							<CreateServer />
 						</Route>
-						<Route path="/connect">
+						<Route path="/connect/:id">
 							<ConnectJenkins />
 						</Route>
 						<Route path="/manage/:id">

--- a/app/jenkins-for-jira-ui/src/components/ConnectJenkins/ConfigurationSteps/ConfigurationSteps.test.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectJenkins/ConfigurationSteps/ConfigurationSteps.test.tsx
@@ -3,6 +3,10 @@ import { render, screen } from '@testing-library/react';
 
 import { ConfigurationSteps } from './ConfigurationSteps';
 
+const disabledStageStyle = 'color: rgb(165, 173, 186); font-weight: 600;';
+const currentStageStyle = 'color: rgb(0, 101, 255); font-weight: 600;';
+const unvisitedStageStyle = 'color: rgb(94, 108, 132); font-weight: 400;';
+
 // Note: Using getByText() in this test as AtlasKit does not give you the ability to attach a testId to the elements.
 
 describe('ConfigurationSteps Page Suite', () => {
@@ -18,9 +22,9 @@ describe('ConfigurationSteps Page Suite', () => {
 		const InstallJenkinsStep = screen.getByText('Install plugin');
 		const CreateServerStep = screen.getByText('Create server');
 		const ConnectServerStep = screen.getByText('Connect server');
-		expect(InstallJenkinsStep).toHaveAttribute('style', 'color: rgb(0, 101, 255); font-weight: 600;');
-		expect(CreateServerStep).toHaveAttribute('style', 'color: rgb(94, 108, 132); font-weight: 400;');
-		expect(ConnectServerStep).toHaveAttribute('style', 'color: rgb(94, 108, 132); font-weight: 400;');
+		expect(InstallJenkinsStep).toHaveAttribute('style', currentStageStyle);
+		expect(CreateServerStep).toHaveAttribute('style', unvisitedStageStyle);
+		expect(ConnectServerStep).toHaveAttribute('style', unvisitedStageStyle);
 	});
 
 	it('Should render correctly with create as currentStage', () => {
@@ -30,9 +34,9 @@ describe('ConfigurationSteps Page Suite', () => {
 		const ConnectServerStep = screen.getByText('Connect server');
 
 		// Visited steps are styled via parent container
-		expect(InstallJenkinsStepParentContainer).toHaveAttribute('style', 'color: rgb(165, 173, 186); font-weight: 600;');
-		expect(CreateServerStep).toHaveAttribute('style', 'color: rgb(0, 101, 255); font-weight: 600;');
-		expect(ConnectServerStep).toHaveAttribute('style', 'color: rgb(94, 108, 132); font-weight: 400;');
+		expect(InstallJenkinsStepParentContainer).toHaveAttribute('style', disabledStageStyle);
+		expect(CreateServerStep).toHaveAttribute('style', currentStageStyle);
+		expect(ConnectServerStep).toHaveAttribute('style', unvisitedStageStyle);
 	});
 
 	it('Should render correctly with connect as currentStage', () => {
@@ -42,8 +46,8 @@ describe('ConfigurationSteps Page Suite', () => {
 		const ConnectServerStep = screen.getByText('Connect server');
 
 		// Visited steps are styled via parent container
-		expect(InstallJenkinsStepParentContainer).toHaveAttribute('style', 'color: rgb(165, 173, 186); font-weight: 600;');
-		expect(CreateServerStepParentContainer).toHaveAttribute('style', 'color: rgb(165, 173, 186); font-weight: 600;');
-		expect(ConnectServerStep).toHaveAttribute('style', 'color: rgb(0, 101, 255); font-weight: 600;');
+		expect(InstallJenkinsStepParentContainer).toHaveAttribute('style', disabledStageStyle);
+		expect(CreateServerStepParentContainer).toHaveAttribute('style', disabledStageStyle);
+		expect(ConnectServerStep).toHaveAttribute('style', currentStageStyle);
 	});
 });

--- a/app/jenkins-for-jira-ui/src/components/ConnectJenkins/ConfigurationSteps/ConfigurationSteps.test.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectJenkins/ConfigurationSteps/ConfigurationSteps.test.tsx
@@ -30,7 +30,7 @@ describe('ConfigurationSteps Page Suite', () => {
 		const ConnectServerStep = screen.getByText('Connect server');
 
 		// Visited steps are styled via parent container
-		expect(InstallJenkinsStepParentContainer).toHaveAttribute('style', 'color: rgb(23, 43, 77); font-weight: 600;');
+		expect(InstallJenkinsStepParentContainer).toHaveAttribute('style', 'color: rgb(165, 173, 186); font-weight: 600;');
 		expect(CreateServerStep).toHaveAttribute('style', 'color: rgb(0, 101, 255); font-weight: 600;');
 		expect(ConnectServerStep).toHaveAttribute('style', 'color: rgb(94, 108, 132); font-weight: 400;');
 	});
@@ -42,8 +42,8 @@ describe('ConfigurationSteps Page Suite', () => {
 		const ConnectServerStep = screen.getByText('Connect server');
 
 		// Visited steps are styled via parent container
-		expect(InstallJenkinsStepParentContainer).toHaveAttribute('style', 'color: rgb(23, 43, 77); font-weight: 600;');
-		expect(CreateServerStepParentContainer).toHaveAttribute('style', 'color: rgb(23, 43, 77); font-weight: 600;');
+		expect(InstallJenkinsStepParentContainer).toHaveAttribute('style', 'color: rgb(165, 173, 186); font-weight: 600;');
+		expect(CreateServerStepParentContainer).toHaveAttribute('style', 'color: rgb(165, 173, 186); font-weight: 600;');
 		expect(ConnectServerStep).toHaveAttribute('style', 'color: rgb(0, 101, 255); font-weight: 600;');
 	});
 });

--- a/app/jenkins-for-jira-ui/src/components/ConnectJenkins/ConfigurationSteps/ConfigurationSteps.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectJenkins/ConfigurationSteps/ConfigurationSteps.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 // TODO: Find out why the Atlassian and Forge packages break ESLint
 // eslint-disable-next-line
 import { ProgressTracker, Stages } from '@atlaskit/progress-tracker';
-import { useHistory } from 'react-router';
 import { progressTrackerContainer } from './ConfigurationSteps.styles';
 
 type AppProps = {
@@ -12,8 +11,6 @@ type AppProps = {
 // This is not reusable for other configuration steps.
 // Choosing to apply YAGNI for now.
 const ConfigurationSteps = ({ currentStage }: AppProps) => {
-	const history = useHistory();
-
 	const stages: { [key: string]: Stages } = {
 		install: [
 			{
@@ -21,8 +18,7 @@ const ConfigurationSteps = ({ currentStage }: AppProps) => {
 				label: 'Install plugin',
 				percentageComplete: 0,
 				status: 'current',
-				href: '#',
-				onClick: () => history.push('/install')
+				href: '#'
 			},
 			{
 				id: 'create',
@@ -44,17 +40,15 @@ const ConfigurationSteps = ({ currentStage }: AppProps) => {
 				id: 'install',
 				label: 'Install plugin',
 				percentageComplete: 100,
-				status: 'visited',
-				href: '#',
-				onClick: () => history.push('/install')
+				status: 'disabled',
+				href: '#'
 			},
 			{
 				id: 'create',
 				label: 'Create server',
 				percentageComplete: 0,
 				status: 'current',
-				href: '#',
-				onClick: () => history.push('/create')
+				href: '#'
 			},
 			{
 				id: 'connect',
@@ -69,17 +63,15 @@ const ConfigurationSteps = ({ currentStage }: AppProps) => {
 				id: 'install',
 				label: 'Install plugin',
 				percentageComplete: 100,
-				status: 'visited',
-				href: '#',
-				onClick: () => history.push('/install')
+				status: 'disabled',
+				href: '#'
 			},
 			{
 				id: 'create',
 				label: 'Create server',
 				percentageComplete: 100,
-				status: 'visited',
-				href: '#',
-				onClick: () => history.push('/create')
+				status: 'disabled',
+				href: '#'
 			},
 			{
 				id: 'connect',

--- a/app/jenkins-for-jira-ui/src/components/ConnectJenkins/ConnectJenkins/ConnectJenkins.test.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectJenkins/ConnectJenkins/ConnectJenkins.test.tsx
@@ -1,8 +1,5 @@
-import { useEffect } from 'react';
-import { renderHook } from '@testing-library/react-hooks';
 import {
 	render,
-	waitFor,
 	screen
 } from '@testing-library/react';
 import { ConnectJenkins } from './ConnectJenkins';
@@ -15,26 +12,14 @@ jest.mock('uuid', () => {
 	return { v4: uuidGen };
 });
 
+jest.mock('react-router', () => ({
+	...jest.requireActual('react-router'),
+	useParams: jest.fn().mockReturnValue({ id: 'uuid_1' })
+}));
+
 describe('ConnectJenkins Page Suite', () => {
 	it('Should not render form if there is no webhookUrl', () => {
 		render(<ConnectJenkins />);
 		expect(screen.queryByTestId('jenkinsConfigurationForm')).not.toBeInTheDocument();
-	});
-
-	it('Should render form if there request as returned webhookUrl', async () => {
-		render(<ConnectJenkins />);
-
-		const { rerender } = renderHook(
-			({ uuid }) => {
-				useEffect(() => {}, [uuid]);
-			},
-			{
-				initialProps: { uuid: '' }
-			}
-		);
-
-		rerender({ uuid: 'uuid_1' });
-
-		expect(await waitFor(() => screen.getByTestId('jenkinsConfigurationForm'))).toBeInTheDocument();
 	});
 });

--- a/app/jenkins-for-jira-ui/src/components/ConnectJenkins/CreateServer/CreateServer.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectJenkins/CreateServer/CreateServer.tsx
@@ -26,15 +26,16 @@ const CreateServer = () => {
 	const onSubmitCreateServer = async () => {
 		if (isFormValid(serverName, setHasError, setErrorMessage)) {
 			setIsLoading(true);
+			const uuid = uuidv4();
 
 			try {
 				await createJenkinsServer({
 					name: serverName,
-					uuid: uuidv4(),
+					uuid,
 					secret: generateNewSecret(),
 					pipelines: []
 				});
-				history.push('/connect');
+				history.push(`/connect/${uuid}`);
 			} catch (e) {
 				console.error('Error: ', e);
 				setIsLoading(false);
@@ -60,13 +61,14 @@ const CreateServer = () => {
 								hasError={hasError}
 								errorMessage={errorMessage}
 								setHasError={setHasError}
+								serverNameHelperText={'Enter a name for your server. You can change this at any time.'}
 							/>
 
 							<FormFooter>
 								{isLoading
 									? <LoadingButton appearance='primary' isLoading className={loadingIcon} testId='loading-button' />
 									:	<Button type='submit' appearance='primary' testId='submit-button'>
-										Next
+										Create
 									</Button>
 								}
 							</FormFooter>

--- a/app/jenkins-for-jira-ui/src/components/JenkinsConfigurationForm/ServerConfigurationFormElements/ServerConfigurationFormName/ServerConfigurationFormName.tsx
+++ b/app/jenkins-for-jira-ui/src/components/JenkinsConfigurationForm/ServerConfigurationFormElements/ServerConfigurationFormName/ServerConfigurationFormName.tsx
@@ -2,17 +2,18 @@ import React, { Fragment } from 'react';
 import Textfield from '@atlaskit/textfield';
 import {
 	ErrorMessage,
-	Field
+	Field, HelperMessage
 } from '@atlaskit/form';
 import {
 	StyledInputHeaderContainer,
-	StyledTextfieldErrorContainer
+	StyledTextfieldErrorContainer, textfieldContainer
 } from '../../JenkinsConfigurationForm.styles';
 import { FormTooltip } from '../../../Tooltip/Tooltip';
 
 type ServerConfigurationFormNameProps = {
 	serverName: string;
 	setServerName: (event: React.ChangeEvent<HTMLInputElement>) => void;
+	serverNameHelperText?: string;
 	hasError: boolean;
 	errorMessage?: string;
 	setHasError: (error: boolean) => boolean | void;
@@ -21,6 +22,7 @@ type ServerConfigurationFormNameProps = {
 const ServerConfigurationFormName = ({
 	serverName,
 	setServerName,
+	serverNameHelperText = '',
 	hasError,
 	errorMessage,
 	setHasError
@@ -38,16 +40,24 @@ const ServerConfigurationFormName = ({
 			<StyledTextfieldErrorContainer hasError={hasError}>
 				<Field label='Server name' name='server-name-label'>
 					{() => (
-						<Textfield
-							name='server-name'
-							value={serverName}
-							aria-label='server name field'
-							testId='server-name'
-							onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-								setServerName(event);
-								setHasError(false);
-							}}
-						/>
+						<Fragment>
+							<div className={textfieldContainer}>
+								<Textfield
+									name='server-name'
+									value={serverName}
+									aria-label='server name field'
+									testId='server-name'
+									onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+										setServerName(event);
+										setHasError(false);
+									}}
+								/>
+							</div>
+
+							<HelperMessage>
+								{serverNameHelperText}
+							</HelperMessage>
+						</Fragment>
 					)}
 				</Field>
 				{ hasError && (


### PR DESCRIPTION
**Context**
Due to a confusing Jenkins server connection flow, we have decided to split the Jenkins server connection flow into 3 steps. For more information, [see here](https://hello.atlassian.net/wiki/spaces/PF/pages/1793379128/JFA+ARC-1264+-+Split+Connection+Screen+plan+and+ideation).

**Changes in this PR**
This PR passes newly created server id to the `ConnectJenkins` component (step 3 in the workflow), and has it display the newly created server details.

Create server - Step 2:
<img width="701" alt="image" src="https://user-images.githubusercontent.com/28718897/181429359-b7eeaf99-36f3-4c87-8f12-bd9484ed2c1c.png">

Connect server - Step 3: 
<img width="753" alt="image" src="https://user-images.githubusercontent.com/28718897/181429389-084d72d7-9835-47d4-aa7e-bdef265d8d58.png">

When clicking "Done" on the "Connect server" screen, it will update any details you provide it.

Note: I have ensured that the title and steps are still rendered when retrieving the server details on the "Connect server" screen. This makes for a smoother transition between the steps.
<img width="715" alt="image" src="https://user-images.githubusercontent.com/28718897/181429608-9e232368-7d4e-45a4-84b7-c9b93a2d132e.png">

These changes also remove the links from the progress tracker to prevent users from moving back a step
<img width="790" alt="image" src="https://user-images.githubusercontent.com/28718897/181434384-179ba7c5-c82d-46fe-8d7a-c0576041a2ca.png">
