### PR TITLE
ARC-1667 Update copy for the server name tooltip

### DIFF
--- a/app/jenkins-for-jira-ui/src/components/JenkinsConfigurationForm/ServerConfigurationFormElements/ServerConfigurationFormName/ServerConfigurationFormName.tsx
+++ b/app/jenkins-for-jira-ui/src/components/JenkinsConfigurationForm/ServerConfigurationFormElements/ServerConfigurationFormName/ServerConfigurationFormName.tsx
@@ -32,7 +32,7 @@ const ServerConfigurationFormName = ({
 			<StyledInputHeaderContainer>
 				<h3>Jenkins server name</h3>
 				<FormTooltip
-					content='Create a display name for your Jenkins server.'
+					content='Edit the display name for your Jenkins server.'
 					label='Jenkins Server'
 				/>
 			</StyledInputHeaderContainer>


### PR DESCRIPTION
**Context**
Due to a confusing Jenkins server connection flow, we have decided to split the Jenkins server connection flow into 3 steps. For more information, [see here](https://hello.atlassian.net/wiki/spaces/PF/pages/1793379128/JFA+ARC-1264+-+Split+Connection+Screen+plan+and+ideation).

**Changes in this PR**
This PR updates the copy for the server name form tooltip.
<img width="625" alt="image" src="https://user-images.githubusercontent.com/28718897/188052281-c02b5066-c338-40fa-8dc1-a8deabf23f23.png">
