### PR TITLE
ARC-437 update renovate config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ build
 **/.env
 
 .idea
+
+#log
+yarn-error.log

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "title": "Jenkins for Jira Renovate configuration",
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "properties": {
     "reviewers": [
       "bgvozdev",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,38 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "@atlassian:fusion-arc-renovate-config"
-  ]
+  "title": "Jenkins for Jira Renovate configuration",
+  "properties": {
+    "reviewers": [
+      "bgvozdev",
+      "atrigueiro",
+      "rrathbone",
+      "mboudreau",
+      "jkay",
+      "gxue",
+      "hsingh5",
+      "kmaharjan4"
+    ],
+    "reviewersSampleSize": 2,
+    "separateMinorPatch": true,
+    "packageRules": [
+      {
+        "matchPackageNames": [
+          "aws-sdk"
+        ]
+      },
+      {
+        "matchUpdateTypes": [
+          "minor",
+          "patch"
+        ]
+      }
+    ],
+    "timezone": "Australia/Sydney",
+    "schedule": [
+      "on Monday and Wednesday"
+    ],
+    "dependencyDashboard": true,
+    "prBodyNotes": [
+      "Have a look at your [dependency dashboard](https://statlas.prod.atl-paas.net/renovate-dashboards/{{repository}}.html)"
+    ]
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
   "reviewers": [
     "bgvozdev",
     "atrigueiro",
@@ -10,7 +13,7 @@
     "hsingh5",
     "kmaharjan4"
   ],
-  "reviewersSampleSize": 2,
+  "reviewersSampleSize": 1,
   "separateMinorPatch": true,
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -1,39 +1,36 @@
 {
-  "title": "Jenkins for Jira Renovate configuration",
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "properties": {
-    "reviewers": [
-      "bgvozdev",
-      "atrigueiro",
-      "rrathbone",
-      "mboudreau",
-      "jkay",
-      "gxue",
-      "hsingh5",
-      "kmaharjan4"
-    ],
-    "reviewersSampleSize": 2,
-    "separateMinorPatch": true,
-    "packageRules": [
-      {
-        "matchPackageNames": [
-          "aws-sdk"
-        ]
-      },
-      {
-        "matchUpdateTypes": [
-          "minor",
-          "patch"
-        ]
-      }
-    ],
-    "timezone": "Australia/Sydney",
-    "schedule": [
-      "on Monday and Wednesday"
-    ],
-    "dependencyDashboard": true,
-    "prBodyNotes": [
-      "Have a look at your [dependency dashboard](https://statlas.prod.atl-paas.net/renovate-dashboards/{{repository}}.html)"
-    ]
-  }
+  "reviewers": [
+    "bgvozdev",
+    "atrigueiro",
+    "rrathbone",
+    "mboudreau",
+    "jkay",
+    "gxue",
+    "hsingh5",
+    "kmaharjan4"
+  ],
+  "reviewersSampleSize": 2,
+  "separateMinorPatch": true,
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "aws-sdk"
+      ]
+    },
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ]
+    }
+  ],
+  "timezone": "Australia/Sydney",
+  "schedule": [
+    "on Monday and Wednesday"
+  ],
+  "dependencyDashboard": true,
+  "prBodyNotes": [
+    "Have a look at your [dependency dashboard](https://statlas.prod.atl-paas.net/renovate-dashboards/{{repository}}.html)"
+  ]
 }


### PR DESCRIPTION
Updated renovate.json so that Jenkins has it's own configuration. We were previously pointing to the main config that's also used by DSS, but that's now been updated so Renovate can automatically merge patch bumps to master. DSS is fairly reliable, and has solid CICD, so we do not want to allow the bot to do this automatically for Jenkins at this point in time.