### PR TITLE
add back button to pending state screen

### DIFF
--- a/app/jenkins-for-jira-ui/src/api/getAllJenkinsServers.ts
+++ b/app/jenkins-for-jira-ui/src/api/getAllJenkinsServers.ts
@@ -68,7 +68,7 @@ const getAllJenkinsServers = async (): Promise<JenkinsServer[]> => {
 			);
 		}
 
-		log({ eventType: 'getAllJenkinsServersSucess' });
+		log({ eventType: 'getAllJenkinsServersSuccess' });
 		return jenkinsServers;
 	} catch (e) {
 		console.error('Failed to get Jenkins servers', e);

--- a/app/jenkins-for-jira-ui/src/common/analytics/analytics-events.ts
+++ b/app/jenkins-for-jira-ui/src/common/analytics/analytics-events.ts
@@ -37,7 +37,8 @@ export enum AnalyticsUiEventsEnum {
 	DisconnectServerConfiguredStateName = 'disconnectServerConfiguredState',
 	DisconnectServerModalClosedConfiguredStateName = 'disconnectServerModalClosedConfiguredState',
 	DisconnectServerConfirmConfiguredStateName = 'disconnectServerConfirmConfiguredState',
-	ManageConnectionPendingStateName = 'manageConnectionPendingState'
+	ManageConnectionPendingStateName = 'manageConnectionPendingState',
+	NavigateBackPendingDeploymentStateName = 'navigateBackPendingDeploymentState'
 }
 
 export enum AnalyticsTrackEventsEnum {

--- a/app/jenkins-for-jira-ui/src/components/JenkinsServerList/PendingDeploymentState/PendingDeploymentState.styles.tsx
+++ b/app/jenkins-for-jira-ui/src/components/JenkinsServerList/PendingDeploymentState/PendingDeploymentState.styles.tsx
@@ -6,13 +6,16 @@ export const pendingDeploymentContainer = css`
 	align-items: center;
 	text-align: center;
 	padding-top: 100px;
-	width: 660px;
 	height: 448px;
 	margin: 0 auto;
 
 	button {
 		max-width: 157px;
 	}
+`;
+
+export const pendingDeploymentInnerContainer = css`
+	width: 660px;
 `;
 
 export const subheadingText = css`

--- a/app/jenkins-for-jira-ui/src/components/JenkinsServerList/PendingDeploymentState/PendingDeploymentState.tsx
+++ b/app/jenkins-for-jira-ui/src/components/JenkinsServerList/PendingDeploymentState/PendingDeploymentState.tsx
@@ -4,12 +4,14 @@ import Button from '@atlaskit/button';
 import { JiraSoftwareIcon } from '@atlaskit/logo';
 import { B200, B400 } from '@atlaskit/theme/colors';
 import Spinner from '@atlaskit/spinner';
+import ArrowLeftIcon from '@atlaskit/icon/glyph/arrow-left';
 import {
 	subheadingText,
 	descriptionText,
 	pendingDeploymentContainer,
 	pendingDeploymentIconContainer,
-	checkSpacer
+	checkSpacer,
+	pendingDeploymentInnerContainer
 } from './PendingDeploymentState.styles';
 import { JenkinsIcon } from '../../icons/JenkinsIcon';
 import { getJenkinsServerWithSecret } from '../../../api/getJenkinsServerWithSecret';
@@ -19,13 +21,17 @@ import {
 	AnalyticsUiEventsEnum
 } from '../../../common/analytics/analytics-events';
 import { AnalyticsClient } from '../../../common/analytics/analytics-client';
+import {
+	headerContainer,
+	navigateBackContainer
+} from '../../ManageConnection/ManageConnection.styles';
+
+const analyticsClient = new AnalyticsClient();
 
 interface ParamTypes {
 	id: string;
 	name: string;
 }
-
-const analyticsClient = new AnalyticsClient();
 
 const PendingDeploymentState = () => {
 	const history = useHistory();
@@ -60,34 +66,75 @@ const PendingDeploymentState = () => {
 		);
 	}, [getServer, jenkinsServerUuid]);
 
+	const handleNavigateBackClick = async (): Promise<void> => {
+		await analyticsClient.sendAnalytics(
+			AnalyticsEventTypes.UiEvent,
+			AnalyticsUiEventsEnum.NavigateBackPendingDeploymentStateName,
+			{
+				source: AnalyticsScreenEventsEnum.PendingDeploymentStateScreenName,
+				action: 'clicked back pending deployment state',
+				actionSubject: 'button'
+			}
+		);
+
+		history.push('/');
+	};
+
+	const handleNavigateBackKeyDown = async (event: React.KeyboardEvent): Promise<void> => {
+		if (event.code === 'Enter') {
+			await analyticsClient.sendAnalytics(
+				AnalyticsEventTypes.UiEvent,
+				AnalyticsUiEventsEnum.NavigateBackPendingDeploymentStateName,
+				{
+					source: AnalyticsScreenEventsEnum.PendingDeploymentStateScreenName,
+					action: 'pressed enter key pending deployment state',
+					actionSubject: 'keydown'
+				}
+			);
+			history.push('/');
+		}
+	};
+
 	return (
 		<div className={pendingDeploymentContainer}>
-			<h2>Waiting for {serverName} deployment event...</h2>
-			<p className={subheadingText}>
-				Include issue keys in your commit messages to start tracking your deployments.{' '}
-				Check back here after a few deployments to verify that it’s working.
-			</p>
+			<header className={headerContainer}>
+				<button
+					className={navigateBackContainer}
+					onClick={handleNavigateBackClick}
+					onKeyDown={handleNavigateBackKeyDown}
+				>
+					<ArrowLeftIcon label="Go back" />
+				</button>
+			</header>
 
-			<div className={pendingDeploymentIconContainer}>
-				<JiraSoftwareIcon
-					iconColor={B200}
-					iconGradientStart={B400}
-					iconGradientStop={B200}
-					size='large'
-				/>
-				<span className={checkSpacer} />
-				<Spinner size='large' />
-				<span className={checkSpacer} />
-				<JenkinsIcon data-testid="jenkins-icon-connect" />
+			<div className={pendingDeploymentInnerContainer}>
+				<h2>Waiting for {serverName} deployment event...</h2>
+				<p className={subheadingText}>
+					Include issue keys in your commit messages to start tracking your deployments.{' '}
+					Check back here after a few deployments to verify that it’s working.
+				</p>
+
+				<div className={pendingDeploymentIconContainer}>
+					<JiraSoftwareIcon
+						iconColor={B200}
+						iconGradientStart={B400}
+						iconGradientStop={B200}
+						size='large'
+					/>
+					<span className={checkSpacer} />
+					<Spinner size='large' />
+					<span className={checkSpacer} />
+					<JenkinsIcon data-testid="jenkins-icon-connect" />
+				</div>
+
+				<p className={descriptionText}>
+					If you have already sent a deployment event,{' '}
+					check that your integration configuration or Jenkinsfile is correct.
+				</p>
+				<Button onClick={() => onClickManage()}>
+					Manage connection
+				</Button>
 			</div>
-
-			<p className={descriptionText}>
-				If you have already sent a deployment event,{' '}
-				check that your integration configuration or Jenkinsfile is correct.
-			</p>
-			<Button onClick={() => onClickManage()}>
-				Manage connection
-			</Button>
 		</div>
 	);
 };


### PR DESCRIPTION
**What's in this PR?**
Added a back button to the pending state screen.

**Why**
There's no way to navigate back (apart from browser buttons)

**Affected issues**  
ARC-2262

**How has this been tested?**  
Locally

https://github.com/atlassian/jenkins-for-jira/assets/37155488/757bcc1d-0016-4d87-a063-84f6a9c95def

**What's Next?**
Was going to add a test but then realised there's no tests at all currently for this page. Created [ARC-2300](https://softwareteams.atlassian.net/jira/software/projects/ARC/boards/385/backlog?selectedIssue=ARC-2300) to add a coverage reporter and then add additional tests to where they are most needed.


[ARC-2300]: https://softwareteams.atlassian.net/browse/ARC-2300