### PR TITLE
ARC-2312 remove port from url

### DIFF
--- a/app/src/common/types.ts
+++ b/app/src/common/types.ts
@@ -20,3 +20,69 @@ export interface JenkinsPipeline {
 	lastEventStatus: BuildEventStatus | DeploymentEventStatus,
 	lastEventType: EventType
 }
+
+interface CommonProperties {
+	source: string;
+	cloudId: string;
+	jenkinsServerUuid: string;
+}
+
+interface Build {
+	pipelineId: string;
+	buildNumber: number;
+	updateSequenceNumber: number;
+	displayName: string;
+	description: null;
+	label: string;
+	url: string;
+	state: string;
+	lastUpdated: string;
+	issueKeys: string[];
+	references: null;
+	testInfo: null;
+	schemaVersion: string;
+}
+
+interface Association {
+	values: string[];
+	associationType: string;
+}
+
+interface Deployment {
+	deploymentSequenceNumber: number;
+	updateSequenceNumber: number;
+	associations: Association[];
+	displayName: string;
+	url: string;
+	description: string;
+	lastUpdated: string;
+	label: string;
+	state: string;
+	pipeline: {
+		id: string;
+		displayName: string;
+		url: string;
+	};
+	environment: {
+		id: string;
+		displayName: string;
+		type: string;
+	};
+	schemaVersion: string;
+}
+
+export interface PayloadWithBuilds {
+	properties: CommonProperties;
+	providerMetadata: {
+		product: string;
+	};
+	builds: Build[];
+}
+
+export interface PayloadWithDeployments {
+	properties: CommonProperties;
+	providerMetadata: {
+		product: string;
+	};
+	deployments: Deployment[];
+}

--- a/app/src/jira-client/send-event-to-jira.test.ts
+++ b/app/src/jira-client/send-event-to-jira.test.ts
@@ -1,9 +1,37 @@
 import { Errors } from '../common/error-messages';
 import { sendEventToJira } from './send-event-to-jira';
-import { EventType } from '../common/types';
+import { EventType, PayloadWithBuilds } from '../common/types';
 import { InvalidPayloadError } from '../common/error';
 
 describe('deleteDeployments suite', () => {
+	const buildPayload: PayloadWithBuilds = {
+		properties: {
+			source: 'jenkins',
+			cloudId: 'bd32dd17-ba44-4e4c-a63a-e2a79c35585f',
+			jenkinsServerUuid: '8541c521-d4c2-4a3b-a53b-ef78212a3f72',
+		},
+		providerMetadata: {
+			product: 'jenkins',
+		},
+		builds: [
+			{
+				pipelineId: '-1037018184',
+				buildNumber: 1,
+				updateSequenceNumber: 1691138682,
+				displayName: 'testing/TEST-257',
+				description: null,
+				label: '#1',
+				url: 'http://example.com:8080/job/new/job/TEST-389-prod-test/2/',
+				state: 'successful',
+				lastUpdated: '2023-08-04T08:44:42.300504Z',
+				issueKeys: ['TEST-257'],
+				references: null,
+				testInfo: null,
+				schemaVersion: '1.0',
+			},
+		],
+	};
+
 	it('Should throw an error if no eventType is passed', async () => {
 		(global as any).api = {
 			asApp: () => ({
@@ -11,9 +39,9 @@ describe('deleteDeployments suite', () => {
 			})
 		};
 
-		expect(async () => {
+		await expect(async () => {
 			// @ts-ignore
-			await sendEventToJira(null, '1234', { thing: 'value' });
+			await sendEventToJira(null, '1234', buildPayload);
 		}).rejects.toThrow(new InvalidPayloadError(Errors.MISSING_REQUIRED_PROPERTIES));
 	});
 
@@ -24,9 +52,9 @@ describe('deleteDeployments suite', () => {
 			})
 		};
 
-		expect(async () => {
+		await expect(async () => {
 			// @ts-ignore
-			await sendEventToJira(EventType.BUILD, null, { thing: 'value' });
+			await sendEventToJira(EventType.BUILD, null, buildPayload);
 		}).rejects.toThrow(new InvalidPayloadError(Errors.MISSING_REQUIRED_PROPERTIES));
 	});
 
@@ -50,9 +78,9 @@ describe('deleteDeployments suite', () => {
 			})
 		};
 
-		expect(async () => {
+		await expect(async () => {
 			// @ts-ignore
-			await sendEventToJira('random event type', '1234', { thing: 'value' });
+			await sendEventToJira('random event type', '1234', buildPayload);
 		}).rejects.toThrow(new InvalidPayloadError(Errors.INVALID_EVENT_TYPE));
 	});
 
@@ -63,7 +91,7 @@ describe('deleteDeployments suite', () => {
 			})
 		};
 
-		const response = await sendEventToJira(EventType.BUILD, '1234', { thing: 'value' });
+		const response = await sendEventToJira(EventType.BUILD, '1234', buildPayload);
 		expect(response).toEqual({ status: 200, body: {} });
 	});
 
@@ -93,7 +121,7 @@ describe('deleteDeployments suite', () => {
 			})
 		};
 
-		const response = await sendEventToJira(EventType.DEPLOYMENT, '1234', { thing: 'value' });
+		const response = await sendEventToJira(EventType.DEPLOYMENT, '1234', buildPayload);
 		expect(response).toEqual({ status: 200, body: { data: resPayload.data } });
 	});
 });

--- a/app/src/jira-client/send-event-to-jira.ts
+++ b/app/src/jira-client/send-event-to-jira.ts
@@ -14,12 +14,6 @@ async function invokeApi(
 ): Promise<JiraResponse> {
 	const payloadWithPortRemoved = removePortFromJenkinsServerUrl(payload);
 
-	logger.logInfo({
-		eventType,
-		data: payloadWithPortRemoved,
-		message: 'Sending data to Jira with modified url???'
-	});
-
 	// @ts-ignore // required so that Typescript doesn't complain about the missing "api" property
 	// eslint-disable-next-line no-underscore-dangle
 	const apiResponse = await global.api

--- a/app/src/jira-client/send-event-to-jira.ts
+++ b/app/src/jira-client/send-event-to-jira.ts
@@ -13,6 +13,13 @@ async function invokeApi(
 	logger: Logger
 ): Promise<JiraResponse> {
 	const payloadWithPortRemoved = removePortFromJenkinsServerUrl(payload);
+
+	logger.logInfo({
+		eventType,
+		data: payloadWithPortRemoved,
+		message: 'Sending data to Jira with modified url???'
+	});
+
 	// @ts-ignore // required so that Typescript doesn't complain about the missing "api" property
 	// eslint-disable-next-line no-underscore-dangle
 	const apiResponse = await global.api

--- a/app/src/jira-client/send-event-to-jira.ts
+++ b/app/src/jira-client/send-event-to-jira.ts
@@ -1,16 +1,18 @@
-import { EventType } from '../common/types';
+import { EventType, PayloadWithBuilds, PayloadWithDeployments } from '../common/types';
 import { InvalidPayloadError } from '../common/error';
 import { JiraResponse } from './types';
 import { Errors } from '../common/error-messages';
 import { Logger } from '../config/logger';
 import { getResponseData } from '../utils/get-data-from-response';
+import { removePortFromJenkinsServerUrl } from '../utils/remove-port-from-jenkins-server-url';
 
 async function invokeApi(
 	url: string,
-	payload: object,
+	payload: PayloadWithBuilds | PayloadWithDeployments,
 	eventType: EventType,
 	logger: Logger
 ): Promise<JiraResponse> {
+	const payloadWithPortRemoved = removePortFromJenkinsServerUrl(payload);
 	// @ts-ignore // required so that Typescript doesn't complain about the missing "api" property
 	// eslint-disable-next-line no-underscore-dangle
 	const apiResponse = await global.api
@@ -20,7 +22,7 @@ async function invokeApi(
 			headers: {
 				'content-type': 'application/json'
 			},
-			body: JSON.stringify(payload)
+			body: JSON.stringify(payloadWithPortRemoved)
 		});
 
 	const responseString = await apiResponse.text();
@@ -56,7 +58,7 @@ async function invokeApi(
 async function sendEventToJira(
 	eventType: EventType,
 	cloudId: string,
-	payload: object
+	payload: PayloadWithBuilds | PayloadWithDeployments
 ): Promise<JiraResponse> {
 	const logger = Logger.getInstance('sendEventToJira');
 

--- a/app/src/utils/remove-port-from-jenkins-server-url.test.ts
+++ b/app/src/utils/remove-port-from-jenkins-server-url.test.ts
@@ -70,6 +70,74 @@ describe('removePortFromJenkinsServerUrl', () => {
         ],
     };
 
+    const modifiedBuildsPayload: PayloadWithBuilds = {
+        properties: {
+            source: 'jenkins',
+            cloudId: 'bd32dd17-ba44-4e4c-a63a-e2a79c35585f',
+            jenkinsServerUuid: '8541c521-d4c2-4a3b-a53b-ef78212a3f72',
+        },
+        providerMetadata: {
+            product: 'jenkins',
+        },
+        builds: [
+            {
+                pipelineId: '-1037018184',
+                buildNumber: 1,
+                updateSequenceNumber: 1691138682,
+                displayName: 'testing/TEST-257',
+                description: null,
+                label: '#1',
+                url: 'http://example.com/job/new/job/TEST-389-prod-test/2/', // Modified URL
+                state: 'successful',
+                lastUpdated: '2023-08-04T08:44:42.300504Z',
+                issueKeys: ['TEST-257'],
+                references: null,
+                testInfo: null,
+                schemaVersion: '1.0',
+            },
+        ],
+    };
+
+    const modifiedDeploymentsPayload: PayloadWithDeployments = {
+        properties: {
+            source: 'jenkins',
+            cloudId: 'bd32dd17-ba44-4e4c-a63a-e2a79c35585f',
+            jenkinsServerUuid: '8541c521-d4c2-4a3b-a53b-ef78212a3f72',
+        },
+        providerMetadata: {
+            product: 'jenkins',
+        },
+        deployments: [
+            {
+                deploymentSequenceNumber: 1,
+                updateSequenceNumber: 1691138688,
+                associations: [
+                    {
+                        values: ['TEST-257'],
+                        associationType: 'issueKeys',
+                    },
+                ],
+                displayName: '#1',
+                url: 'http://example.com/job/new/job/TEST-389-prod-test/2/', // Modified URL
+                description: '#1',
+                lastUpdated: '2023-08-04T08:44:48.141852Z',
+                label: '#1',
+                state: 'in_progress',
+                pipeline: {
+                    id: '-1037018184',
+                    displayName: 'testing/TEST-257',
+                    url: 'http://example.com/job/new/job/TEST-389-prod-test/2/', // Modified URL
+                },
+                environment: {
+                    id: 'stg',
+                    displayName: 'stg',
+                    type: 'staging',
+                },
+                schemaVersion: '1.0',
+            },
+        ],
+    };
+
     it('should remove the port from builds URLs', () => {
         const modifiedPayload: PayloadWithBuilds = { ...buildPayload };
 		removePortFromJenkinsServerUrl(modifiedPayload);
@@ -108,5 +176,17 @@ describe('removePortFromJenkinsServerUrl', () => {
         };
         removePortFromJenkinsServerUrl(modifiedPayload);
         expect(modifiedPayload.builds[0].url).toBe('http://example.com/job/new/job/TEST-389-prod-test/2/');
+    });
+
+    it('should remove the port from builds URLs', () => {
+        const modifiedPayload: PayloadWithBuilds = { ...buildPayload };
+        const result = removePortFromJenkinsServerUrl(modifiedPayload);
+        expect(result).toEqual(modifiedBuildsPayload);
+    });
+
+    it('should remove the port from deployments URLs', () => {
+        const modifiedPayload: PayloadWithDeployments = { ...deploymentPayload };
+        const result = removePortFromJenkinsServerUrl(modifiedPayload);
+        expect(result).toEqual(modifiedDeploymentsPayload);
     });
 });

--- a/app/src/utils/remove-port-from-jenkins-server-url.test.ts
+++ b/app/src/utils/remove-port-from-jenkins-server-url.test.ts
@@ -1,0 +1,112 @@
+import { PayloadWithBuilds, PayloadWithDeployments } from '../common/types';
+import { removePortFromJenkinsServerUrl } from './remove-port-from-jenkins-server-url';
+
+describe('removePortFromJenkinsServerUrl', () => {
+    const buildPayload: PayloadWithBuilds = {
+        properties: {
+            source: 'jenkins',
+            cloudId: 'bd32dd17-ba44-4e4c-a63a-e2a79c35585f',
+            jenkinsServerUuid: '8541c521-d4c2-4a3b-a53b-ef78212a3f72',
+        },
+        providerMetadata: {
+            product: 'jenkins',
+        },
+        builds: [
+            {
+                pipelineId: '-1037018184',
+                buildNumber: 1,
+                updateSequenceNumber: 1691138682,
+                displayName: 'testing/TEST-257',
+                description: null,
+                label: '#1',
+                url: 'http://example.com:8080/job/new/job/TEST-389-prod-test/2/',
+                state: 'successful',
+                lastUpdated: '2023-08-04T08:44:42.300504Z',
+                issueKeys: ['TEST-257'],
+                references: null,
+                testInfo: null,
+                schemaVersion: '1.0',
+            },
+        ],
+    };
+
+    const deploymentPayload: PayloadWithDeployments = {
+        properties: {
+            source: 'jenkins',
+            cloudId: 'bd32dd17-ba44-4e4c-a63a-e2a79c35585f',
+            jenkinsServerUuid: '8541c521-d4c2-4a3b-a53b-ef78212a3f72',
+        },
+        providerMetadata: {
+            product: 'jenkins',
+        },
+        deployments: [
+            {
+                deploymentSequenceNumber: 1,
+                updateSequenceNumber: 1691138688,
+                associations: [
+                    {
+                        values: ['TEST-257'],
+                        associationType: 'issueKeys',
+                    },
+                ],
+                displayName: '#1',
+                url: 'http://example.com:8080/job/new/job/TEST-389-prod-test/2/',
+                description: '#1',
+                lastUpdated: '2023-08-04T08:44:48.141852Z',
+                label: '#1',
+                state: 'in_progress',
+                pipeline: {
+                    id: '-1037018184',
+                    displayName: 'testing/TEST-257',
+                    url: 'http://example.com:8080/job/new/job/TEST-389-prod-test/2/',
+                },
+                environment: {
+                    id: 'stg',
+                    displayName: 'stg',
+                    type: 'staging',
+                },
+                schemaVersion: '1.0',
+            },
+        ],
+    };
+
+    it('should remove the port from builds URLs', () => {
+        const modifiedPayload: PayloadWithBuilds = { ...buildPayload };
+		removePortFromJenkinsServerUrl(modifiedPayload);
+        expect(modifiedPayload.builds[0].url).toBe('http://example.com/job/new/job/TEST-389-prod-test/2/');
+    });
+
+    it('should remove the port from deployments URLs', () => {
+        const modifiedPayload: PayloadWithDeployments = { ...deploymentPayload };
+        removePortFromJenkinsServerUrl(modifiedPayload);
+        expect(modifiedPayload.deployments[0].url).toBe('http://example.com/job/new/job/TEST-389-prod-test/2/');
+    });
+
+    it('should not remove the port from localhost URLs', () => {
+        const modifiedPayload: PayloadWithBuilds = {
+            ...buildPayload,
+            builds: [
+                {
+                    ...buildPayload.builds[0],
+                    url: 'http://localhost:3000/job/new/job/TEST-389-prod-test/2/',
+                },
+            ],
+        };
+        removePortFromJenkinsServerUrl(modifiedPayload);
+        expect(modifiedPayload.builds[0].url).toBe('http://localhost:3000/job/new/job/TEST-389-prod-test/2/');
+    });
+
+    it('should not change URLs without a port', () => {
+        const modifiedPayload: PayloadWithBuilds = {
+            ...buildPayload,
+            builds: [
+                {
+                    ...buildPayload.builds[0],
+                    url: 'http://example.com/job/new/job/TEST-389-prod-test/2/',
+                },
+            ],
+        };
+        removePortFromJenkinsServerUrl(modifiedPayload);
+        expect(modifiedPayload.builds[0].url).toBe('http://example.com/job/new/job/TEST-389-prod-test/2/');
+    });
+});

--- a/app/src/utils/remove-port-from-jenkins-server-url.ts
+++ b/app/src/utils/remove-port-from-jenkins-server-url.ts
@@ -1,0 +1,19 @@
+import { PayloadWithBuilds, PayloadWithDeployments } from '../common/types';
+
+export const removePortFromJenkinsServerUrl = (payload: PayloadWithBuilds | PayloadWithDeployments): void => {
+    const localHostRegex = /:\/\/localhost(:\d+)?/;
+
+    if ('builds' in payload) {
+        payload.builds.forEach((build) => {
+            if (!localHostRegex.test(build.url)) {
+                build.url = build.url.replace(/:\d+/, '');
+            }
+        });
+    } else if ('deployments' in payload) {
+        payload.deployments.forEach((deployment) => {
+            if (!localHostRegex.test(deployment.url)) {
+                deployment.url = deployment.url.replace(/:\d+/, '');
+            }
+        });
+    }
+};

--- a/app/src/utils/remove-port-from-jenkins-server-url.ts
+++ b/app/src/utils/remove-port-from-jenkins-server-url.ts
@@ -1,6 +1,8 @@
 import { PayloadWithBuilds, PayloadWithDeployments } from '../common/types';
 
-export const removePortFromJenkinsServerUrl = (payload: PayloadWithBuilds | PayloadWithDeployments): void => {
+export const removePortFromJenkinsServerUrl = (
+    payload: PayloadWithBuilds | PayloadWithDeployments
+): PayloadWithBuilds | PayloadWithDeployments => {
     const localHostRegex = /:\/\/localhost(:\d+)?/;
 
     if ('builds' in payload) {
@@ -14,6 +16,12 @@ export const removePortFromJenkinsServerUrl = (payload: PayloadWithBuilds | Payl
             if (!localHostRegex.test(deployment.url)) {
                 deployment.url = deployment.url.replace(/:\d+/, '');
             }
+            // Also modify the URL in the pipeline object
+            if (deployment.pipeline && !localHostRegex.test(deployment.pipeline.url)) {
+                deployment.pipeline.url = deployment.pipeline.url.replace(/:\d+/, '');
+            }
         });
     }
+
+    return payload;
 };


### PR DESCRIPTION
**What's in this PR?**
Main thing is a function to remove the port from urls (but not localhost), along with the tightening up of some types.

**Why**
Because links in Jira back to Jenkins are broken because we're passing in a port number. If there's no port, the URL will remain unchanged.

**Added feature flags**
TODO - waiting on project to be created.

**Affected issues**  
ARC-2312

**How has this been tested?**  
Locally and unit test

Local recording of clicking a link in an issue pre-port removal, and on another issue post-port removal.

Uploading Screen Recording 2023-08-07 at 2.30.03 pm.mov… (refusing to upload this one :sigh:)

Staging recording of all links working for builds and deployments in dev panel.

https://github.com/atlassian/jenkins-for-jira/assets/37155488/179030da-6105-46c0-9b91-7a8a559473ad


**What's Next?**
Profit.