### PR TITLE
ARC-2412 add useAsGetStarted prop

### DIFF
--- a/app/manifest.yml
+++ b/app/manifest.yml
@@ -7,6 +7,7 @@ modules:
       title: Jenkins for Jira
       layout: basic
       icon: https://marketplace-cdn.atlassian.com/files/0c45cd96-ccf1-4490-9df4-307dded2f6e0?fileType=image&mode=full-fit
+      useAsGetStarted: true
   webtrigger:
     - key: jenkins-webtrigger
       function: handle-jenkins-request


### PR DESCRIPTION
**What's in this PR?**
Addition of useAsGetStarted to manifest

**Why**
To expose the Get started button when you go to manage apps and to expose the Get started link in the flag.

**Affected issues**  
ARC-2412

**How has this been tested?**  
Locally

