### PR TITLE
NONE remove ff for generating secret on backend

### DIFF
--- a/app/jenkins-for-jira-ui/src/components/ConnectJenkins/CreateServer/CreateServer.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectJenkins/CreateServer/CreateServer.tsx
@@ -22,13 +22,10 @@ import {
 	AnalyticsUiEventsEnum
 } from '../../../common/analytics/analytics-events';
 import { generateNewSecret } from '../../../api/generateNewSecret';
-import { generateNewSecretUNSAFE } from '../../JenkinsConfigurationForm/JenkinsConfigurationForm';
-import { FeatureFlags, useFeatureFlag } from '../../../hooks/useFeatureFlag';
 
 const analyticsClient = new AnalyticsClient();
 
 const CreateServer = () => {
-	const serverSecretGenerationFlag = useFeatureFlag<boolean>(FeatureFlags.SERVER_SECRET_GENERATION);
 	const history = useHistory();
 	const [serverName, setServerName] = useState('');
 	const [hasError, setHasError] = useState(false);
@@ -61,7 +58,7 @@ const CreateServer = () => {
 				await createJenkinsServer({
 					name: serverName,
 					uuid,
-					secret: serverSecretGenerationFlag ? await generateNewSecret() : generateNewSecretUNSAFE(),
+					secret: await generateNewSecret(),
 					pipelines: []
 				});
 

--- a/app/jenkins-for-jira-ui/src/components/JenkinsConfigurationForm/JenkinsConfigurationForm.tsx
+++ b/app/jenkins-for-jira-ui/src/components/JenkinsConfigurationForm/JenkinsConfigurationForm.tsx
@@ -17,24 +17,6 @@ import {
 	AnalyticsUiEventsEnum
 } from '../../common/analytics/analytics-events';
 import { generateNewSecret } from '../../api/generateNewSecret';
-import { FeatureFlags, useFeatureFlag } from '../../hooks/useFeatureFlag';
-
-const charactersForSecret =
-	'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-
-export const generateNewSecretUNSAFE = () => {
-	const SECRET_LENGTH = 20;
-	let newSecret = '';
-	const numberOfSecretCharacters = charactersForSecret.length;
-
-	for (let i = 0; i < SECRET_LENGTH; i++) {
-		newSecret += charactersForSecret.charAt(
-			Math.floor(Math.random() * numberOfSecretCharacters)
-		);
-	}
-
-	return newSecret;
-};
 
 type JenkinsConfigurationFormProps = {
 	onSubmit(): void;
@@ -66,7 +48,6 @@ const JenkinsConfigurationForm = ({
 	pageTitle
 }: JenkinsConfigurationFormProps) => {
 	const analyticsClient = new AnalyticsClient();
-	const serverSecretGenerationFlag = useFeatureFlag<boolean>(FeatureFlags.SERVER_SECRET_GENERATION);
 	const [showConfirmRefreshSecret, setShowConfirmRefreshSecret] =
 		useState(false);
 	const isOnManageConnectPage = pageTitle.includes('Manage');
@@ -76,11 +57,7 @@ const JenkinsConfigurationForm = ({
 
 	const refreshSecret = async (event: React.MouseEvent<HTMLElement>) => {
 		event.preventDefault();
-		if (serverSecretGenerationFlag) {
-			setSecret(await generateNewSecret());
-		} else {
-			setSecret(generateNewSecretUNSAFE());
-		}
+		setSecret(await generateNewSecret());
 
 		setShowConfirmRefreshSecret(false);
 


### PR DESCRIPTION
**What's in this PR?**
Removing FF to generate the secret on the backend vs frontend.

**Why**
Coz it's been at 100% for a couple of weeks and all looks good. And we need to remove these bad boys once we're done with them :_wink:

**Added feature flags**
Nah, just removing one

**Affected issues**  
NONE

**How has this been tested?**  
Locally

**What's Next?**
Delete the actual feature flag :excellentburnsgif:
