### PR TITLE
add resolver to pass cloud id

### DIFF
--- a/app/jenkins-for-jira-ui/src/api/fetchCloudId.test.ts
+++ b/app/jenkins-for-jira-ui/src/api/fetchCloudId.test.ts
@@ -1,0 +1,9 @@
+import { invoke } from '@forge/bridge';
+import { fetchCloudId } from './fetchCloudId';
+
+describe('fetchCloudId', (): void => {
+	it('should invoke fetchCloudId', async (): Promise<void> => {
+		await fetchCloudId();
+		expect(invoke).toHaveBeenCalledWith('fetchCloudId');
+	});
+});

--- a/app/jenkins-for-jira-ui/src/api/fetchCloudId.ts
+++ b/app/jenkins-for-jira-ui/src/api/fetchCloudId.ts
@@ -1,0 +1,10 @@
+import { invoke } from '@forge/bridge';
+
+const fetchCloudId = async (): Promise<string> => {
+	const response: string = await invoke('fetchCloudId');
+	return response;
+};
+
+export {
+	fetchCloudId
+};

--- a/app/src/resolvers.ts
+++ b/app/src/resolvers.ts
@@ -68,4 +68,9 @@ resolver.define('generateNewSecret', async (req) => {
 	return generateNewSecret();
 });
 
+resolver.define('fetchCloudId', async (req): Promise<string> => {
+	await adminPermissionCheck(req);
+	return req.context.cloudId;
+});
+
 export default resolver.getDefinitions();


### PR DESCRIPTION
**What's in this PR?**
Added a new resolver

**Why**
 So the client can make a request to get the cloudId by doing something like:
 
```
const getCloudId = async (): Promise<void> => {
 const id = await fetchCloudId() || '';
 setCloudId(id);
};

useEffect(() => {
 getCloudId();
}, []);
```

**Added feature flags**
n/a

**Affected issues**  
ARC-2585

**How has this been tested?**  
Locally

**What's Next?**
auto deployments!
