### PR TITLE
NONE add custom env var

### DIFF
--- a/app/src/config/env.ts
+++ b/app/src/config/env.ts
@@ -1,13 +1,13 @@
 export interface EnvVars {
     LAUNCHDARKLY_API_KEY: string;
     LAUNCHDARKLY_APP_NAME: string;
-    NODE_ENV: string;
+    JENKINS_ENV: string;
 }
 
 const envVars: EnvVars = {
     LAUNCHDARKLY_API_KEY: process.env.LAUNCHDARKLY_API_KEY || '',
     LAUNCHDARKLY_APP_NAME: process.env.LAUNCHDARKLY_APP_NAME || 'jenkins-for-jira',
-    NODE_ENV: process.env.NODE_ENV || 'development'
+    JENKINS_ENV: process.env.JENKINS_ENV || ''
 };
 
 export type Environment = 'test' | 'development' | 'staging' | 'production';

--- a/app/src/config/feature-flags.ts
+++ b/app/src/config/feature-flags.ts
@@ -120,7 +120,7 @@ export const launchDarklyService = {
 
 export const fetchFeatureFlag = async (featureFlagKey: string, cloudId?: string): Promise<boolean | null> => {
     try {
-        const environment: Environment = envVars.NODE_ENV as Environment;
+        const environment: Environment = envVars.JENKINS_ENV as Environment;
         const featureFlag = await launchDarklyService.getFeatureFlag(featureFlagKey);
         const envData = featureFlag.environments[environment];
 

--- a/app/src/config/feature-flags.ts
+++ b/app/src/config/feature-flags.ts
@@ -120,7 +120,8 @@ export const launchDarklyService = {
 
 export const fetchFeatureFlag = async (featureFlagKey: string, cloudId?: string): Promise<boolean | null> => {
     try {
-        const environment: Environment = envVars.JENKINS_ENV as Environment;
+        const environment: Environment = envVars.JENKINS_ENV as Environment || process.env.NODE_ENV;
+        logger.info('envVars.JENKINS_ENV', { env: envVars.JENKINS_ENV });
         const featureFlag = await launchDarklyService.getFeatureFlag(featureFlagKey);
         const envData = featureFlag.environments[environment];
 

--- a/app/src/config/feature-flags.ts
+++ b/app/src/config/feature-flags.ts
@@ -120,8 +120,9 @@ export const launchDarklyService = {
 
 export const fetchFeatureFlag = async (featureFlagKey: string, cloudId?: string): Promise<boolean | null> => {
     try {
+        // custom env var as Forge overrides NODE_ENV in every environment with production
+        // left NODE_ENV as a fallback as it's needed for tests and pipelines
         const environment: Environment = envVars.JENKINS_ENV as Environment || process.env.NODE_ENV;
-        logger.info('envVars.JENKINS_ENV', { env: envVars.JENKINS_ENV });
         const featureFlag = await launchDarklyService.getFeatureFlag(featureFlagKey);
         const envData = featureFlag.environments[environment];
 


### PR DESCRIPTION
**What's in this PR?**
Added a custom env var

**Why**
Forge doesn't play nice with NODE_ENV and overrides it in every environment with 'production' :sigh:

**Added feature flags**
n/a

**Affected issues**  
none

**How has this been tested?**  
Tested development and staging environments via the official Jenkins app and could see in the logs I'm getting the values I should get from LD. Tested prod as well by registering my own app and deploying it to production. Logs there looked good too.

**What's Next?**
Pray that Forge stop throwing me curveballs.