### PR TITLE
Arc-2676 connected state

### DIFF
--- a/app/jenkins-for-jira-ui/src/App.tsx
+++ b/app/jenkins-for-jira-ui/src/App.tsx
@@ -6,6 +6,7 @@ import {
 } from 'react-router';
 import styled from '@emotion/styled';
 import { view } from '@forge/bridge';
+import { token } from '@atlaskit/tokens';
 import { withLDProvider } from 'launchdarkly-react-client-sdk';
 import { setGlobalTheme } from '@atlaskit/tokens';
 import { InstallJenkins } from './components/ConnectJenkins/InstallJenkins/InstallJenkins';
@@ -54,6 +55,7 @@ export const environmentSettings = {
 const AppContainer = styled.div`
 	color: #172B4D;
 	margin: 24px 36px 24px 0;
+	padding-bottom: ${token('space.300')};
 `;
 
 const App: React.FC = () => {

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectedJenkinsServers.test.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectedJenkinsServers.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import moment from 'moment';
+import '@testing-library/jest-dom/extend-expect';
+import { ConnectedJenkinsServers, timeFromNow } from './ConnectedJenkinsServers';
+import { EventType, JenkinsServer } from '../../../../src/common/types';
+
+describe('timeFromNow util', () => {
+	test('returns correct string for hours', () => {
+		const date = moment().subtract(5, 'hours');
+		const result = timeFromNow(date);
+		expect(result).toEqual('About 5 hours ago');
+	});
+
+	test('returns correct string for single hour', () => {
+		const date = moment().subtract(1, 'hours');
+		const result = timeFromNow(date);
+		expect(result).toEqual('About 1 hour ago');
+	});
+
+	test('returns correct string for minutes', () => {
+		const date = moment().subtract(30, 'minutes');
+		const result = timeFromNow(date);
+		expect(result).toEqual('About 30 minutes ago');
+	});
+
+	test('returns correct string for single minute', () => {
+		const date = moment().subtract(1, 'minutes');
+		const result = timeFromNow(date);
+		expect(result).toEqual('About 1 minute ago');
+	});
+
+	test('returns correct string for seconds', () => {
+		const date = moment().subtract(45, 'seconds');
+		const result = timeFromNow(date);
+		expect(result).toEqual('About 45 seconds ago');
+	});
+
+	test('returns correct string for single second', () => {
+		const date = moment().subtract(1, 'seconds');
+		const result = timeFromNow(date);
+		expect(result).toEqual('About 1 second ago');
+	});
+});
+
+describe('ConnectedJenkinsServers suite', () => {
+	const mockConnectedJenkinsServer: JenkinsServer = {
+		name: 'mockServer',
+		uuid: '123',
+		pipelines: [
+			{
+				name: 'mockPipeline',
+				lastEventStatus: 'successful',
+				lastEventType: EventType.DEPLOYMENT,
+				lastEventDate: new Date()
+			}
+		]
+	};
+
+	test('renders column headers', () => {
+		render(<ConnectedJenkinsServers connectedJenkinsServer={mockConnectedJenkinsServer} />);
+		expect(screen.getByText('Pipeline')).toBeInTheDocument();
+		expect(screen.getByText('Event')).toBeInTheDocument();
+		expect(screen.getByText('Received')).toBeInTheDocument();
+	});
+
+	test('renders correct job & event content', () => {
+		render(<ConnectedJenkinsServers connectedJenkinsServer={mockConnectedJenkinsServer} />);
+		expect(screen.getByText(mockConnectedJenkinsServer.pipelines[0].name)).toBeInTheDocument();
+		expect(screen.getByText('successful deployment')).toBeInTheDocument();
+	});
+
+	test('renders correct time content', () => {
+		render(<ConnectedJenkinsServers connectedJenkinsServer={mockConnectedJenkinsServer} />);
+		const timeContent = moment().diff(moment(new Date(mockConnectedJenkinsServer.pipelines[0].lastEventDate)), 'hours') < 24
+			? timeFromNow(new Date(mockConnectedJenkinsServer.pipelines[0].lastEventDate))
+			: moment(new Date(mockConnectedJenkinsServer.pipelines[0].lastEventDate)).format('Do MMMM YYYY [at] hh:mma');
+		expect(screen.getByText(timeContent)).toBeInTheDocument();
+	});
+});

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectedJenkinsServers.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectedJenkinsServers.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { cx } from '@emotion/css';
+import { JenkinsServer } from '../../../../src/common/types';
+import { connectedStateContainer } from './ConnectionPanel.styles';
+
+type ConnectedStateProps = {
+	connectedJenkinsServers: JenkinsServer[]
+};
+
+const ConnectedJenkinsServers = ({ connectedJenkinsServers }: ConnectedStateProps): JSX.Element => {
+	console.log('connectedJenkinsServers: ', connectedJenkinsServers);
+	return (
+		<div className={cx(connectedStateContainer)}>
+			render table here
+		</div>
+	);
+};
+
+export { ConnectedJenkinsServers };

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectedJenkinsServers.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectedJenkinsServers.tsx
@@ -9,7 +9,8 @@ import {
 } from '../JenkinsServerList/ConnectedServer/ConnectedServers';
 import {
 	connectedStateCell,
-	connectedStateCellContainer, connectedStateCellEvent,
+	connectedStateCellContainer,
+	connectedStateCellEvent,
 	connectedStateContainer
 } from './ConnectionPanel.styles';
 
@@ -31,8 +32,22 @@ type ConnectedStateProps = {
 	connectedJenkinsServer: JenkinsServer
 };
 
+type TableHead = {
+	cells: {
+		key: string;
+		content: string;
+	}[];
+};
+
+interface Row {
+	cells: {
+		key: string;
+		content: React.ReactNode;
+	}[];
+}
+
 const ConnectedJenkinsServers = ({ connectedJenkinsServer }: ConnectedStateProps): JSX.Element => {
-	const tableHead = () => {
+	const tableHead = ():TableHead => {
 		return {
 			cells: [
 				{
@@ -51,9 +66,9 @@ const ConnectedJenkinsServers = ({ connectedJenkinsServer }: ConnectedStateProps
 		};
 	};
 
-	const rows = (serverName: string, serverId: string, pipelines: JenkinsPipeline[] = []) => {
+	const rows = (serverName: string, serverId: string, pipelines: JenkinsPipeline[] = []): Row[] => {
 		return (
-			pipelines.map((pipeline) => ({
+			pipelines.map((pipeline: JenkinsPipeline) => ({
 				cells: [
 					{
 						key: 'job',

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectedJenkinsServers.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectedJenkinsServers.tsx
@@ -1,17 +1,93 @@
 import React from 'react';
+import moment from 'moment/moment';
 import { cx } from '@emotion/css';
-import { JenkinsServer } from '../../../../src/common/types';
-import { connectedStateContainer } from './ConnectionPanel.styles';
+import DynamicTable from '@atlaskit/dynamic-table';
+import { JenkinsPipeline, JenkinsServer } from '../../../../src/common/types';
+import {
+	mapLastEventStatus,
+	mapLastEventStatusIcons
+} from '../JenkinsServerList/ConnectedServer/ConnectedServers';
+import {
+	connectedStateCell,
+	connectedStateCellContainer, connectedStateCellEvent,
+	connectedStateContainer
+} from './ConnectionPanel.styles';
 
 type ConnectedStateProps = {
-	connectedJenkinsServers: JenkinsServer[]
+	connectedJenkinsServer: JenkinsServer
 };
 
-const ConnectedJenkinsServers = ({ connectedJenkinsServers }: ConnectedStateProps): JSX.Element => {
-	console.log('connectedJenkinsServers: ', connectedJenkinsServers);
+const ConnectedJenkinsServers = ({ connectedJenkinsServer }: ConnectedStateProps): JSX.Element => {
+	const tableHead = () => {
+		return {
+			cells: [
+				{
+					key: 'job',
+					content: 'Pipeline'
+				},
+				{
+					key: 'event',
+					content: 'Event'
+				},
+				{
+					key: 'time',
+					content: 'Received'
+				}
+			]
+		};
+	};
+
+	const rows = (serverName: string, serverId: string, pipelines: JenkinsPipeline[] = []) => {
+		return (
+			pipelines.map((pipeline) => ({
+				cells: [
+					{
+						key: 'job',
+						content: (
+							<div className={cx(connectedStateCellContainer)}>
+								<div className={cx(connectedStateCell)}>
+									{pipeline.name}
+								</div>
+							</div>
+						)
+					},
+					{
+						key: 'event',
+						content: (
+							<div className={cx(connectedStateCellContainer)}>
+								<>
+									<div className={cx(connectedStateCell)}>
+										{mapLastEventStatusIcons(pipeline.lastEventStatus)}
+									</div>
+								</>
+								<div className={cx(connectedStateCell, connectedStateCellEvent)}>
+									{mapLastEventStatus(pipeline.lastEventStatus)} {pipeline.lastEventType}
+								</div>
+							</div>
+						)
+					},
+					{
+						key: 'time',
+						content: (
+							<div className={cx(connectedStateCellContainer)}>
+								<div className={cx(connectedStateCell)}>
+									{moment(new Date(pipeline.lastEventDate)).format('Do MMMM YYYY [at] hh:mma')}
+								</div>
+							</div>
+						)
+					}
+				]
+			}))
+		);
+	};
+
 	return (
 		<div className={cx(connectedStateContainer)}>
-			render table here
+			<DynamicTable
+				head={tableHead()}
+				rows={rows(connectedJenkinsServer.name, connectedJenkinsServer.uuid, connectedJenkinsServer.pipelines)}
+				loadingSpinnerSize='large'
+			/>
 		</div>
 	);
 };

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.styles.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.styles.tsx
@@ -70,6 +70,7 @@ export const connectionPanelMainTabs = css`
 	width: 100%;
 `;
 
+// Not connected state
 export const notConnectedStateContainer = css`
 	margin: 0 auto;
 	max-width: 420px;
@@ -100,4 +101,11 @@ export const notConnectedStateParagraph = css`
 	div {
 		margin-bottom: ${token('space.300')}
 	}
+`;
+
+// Connected state
+export const connectedStateContainer = css`
+	margin: 0 auto;
+	max-width: 420px;
+	text-align: center;
 `;

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.styles.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.styles.tsx
@@ -57,9 +57,18 @@ export const connectionPanelMainContainer = css`
 			}
 		}
 	}
+
+	#connection-panel-tabs-0-tab {
+		padding: 0;
+	}
 `;
 
-export const connectionPanelMainTabs = css`
+export const connectionPanelMainConnectedTabs = css`
+	margin-top: ${token('space.100')};
+	width: 100%;
+`;
+
+export const connectionPanelMainNotConnectedTabs = css`
 	align-items: center;
 	border-radius: 3px;
 	display: flex;
@@ -72,7 +81,7 @@ export const connectionPanelMainTabs = css`
 
 // Not connected state
 export const notConnectedStateContainer = css`
-	margin: 0 auto;
+	margin:  ${token('space.0')} auto;
 	max-width: 420px;
 	text-align: center;
 `;
@@ -99,13 +108,30 @@ export const notConnectedStateParagraph = css`
 	margin-bottom: ${token('space.400')};
 
 	div {
-		margin-bottom: ${token('space.300')}
+		margin-bottom: ${token('space.300')};
 	}
 `;
 
 // Connected state
 export const connectedStateContainer = css`
-	margin: 0 auto;
-	max-width: 420px;
-	text-align: center;
+	margin-top: ${token('space.200')};
+`;
+
+export const connectedStateCellContainer = css`
+	align-items: center;
+	display: flex;
+`;
+
+export const connectedStateCell = css`
+	font-size: 14px;
+	line-height: 20px;
+	margin: ${token('space.050')} 0;
+`;
+
+export const connectedStateCellEvent = css`
+	margin-left: ${token('space.100')};
+
+	&:first-letter {
+		text-transform: capitalize;
+	}
 `;

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.tests.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.tests.tsx
@@ -6,7 +6,13 @@ import { ConnectedState } from '../StatusLabel/StatusLabel';
 describe('ConnectionPanelTop', () => {
 	test('renders with the correct content and styles for CONNECTED state', () => {
 		const ipAddress = '10.0.0.1';
-		render(<ConnectionPanelTop connectedState={ConnectedState.CONNECTED} ipAddress={ipAddress} />);
+		render(
+			<ConnectionPanelTop
+				connectedState={ConnectedState.CONNECTED}
+				ipAddress={ipAddress}
+				name="my server"
+			/>
+		);
 
 		const nameLabel = screen.getByText(/Insert name/i);
 		const ipAddressLabel = screen.getByText(`IP address: ${ipAddress}`);
@@ -20,7 +26,13 @@ describe('ConnectionPanelTop', () => {
 
 	test('renders with the correct content and styles for DUPLICATE state', () => {
 		const ipAddress = '10.0.0.1';
-		render(<ConnectionPanelTop connectedState={ConnectedState.DUPLICATE} ipAddress={ipAddress} />);
+		render(
+			<ConnectionPanelTop
+				connectedState={ConnectedState.DUPLICATE}
+				ipAddress={ipAddress}
+				name="my server"
+			/>
+		);
 
 		const nameLabel = screen.getByText(/Insert name/i);
 		const ipAddressLabel = screen.getByText(`IP address: ${ipAddress}`);
@@ -34,7 +46,13 @@ describe('ConnectionPanelTop', () => {
 
 	test('renders with the correct content and styles for PENDING state', () => {
 		const ipAddress = '10.0.0.1';
-		render(<ConnectionPanelTop connectedState={ConnectedState.PENDING} ipAddress={ipAddress} />);
+		render(
+			<ConnectionPanelTop
+				connectedState={ConnectedState.PENDING}
+				ipAddress={ipAddress}
+				name="my server"
+			/>
+		);
 
 		const nameLabel = screen.getByText(/Insert name/i);
 		const ipAddressLabel = screen.getByText(`IP address: ${ipAddress}`);

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.tsx
@@ -33,7 +33,11 @@ const ConnectionPanel = (): JSX.Element => {
 			{jenkinsServers.map(
 				(server: JenkinsServer, index: number): JSX.Element => (
 					<div className={cx(connectionPanelContainer)} key={index}>
-						<ConnectionPanelTop connectedState={server.connectedState || ConnectedState.PENDING} ipAddress="10.10.0.10"/>
+						<ConnectionPanelTop
+							name={server.name}
+							connectedState={server.connectedState || ConnectedState.PENDING}
+							ipAddress="10.10.0.10"
+						/>
 						<ConnectionPanelMain
 							connectedState={server.connectedState || ConnectedState.PENDING}
 							jenkinsServer={server}

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.tsx
@@ -4,21 +4,44 @@ import { ConnectionPanelMain } from './ConnectionPanelMain';
 import { ConnectionPanelTop } from './ConnectionPanelTop';
 import { ConnectedState } from '../StatusLabel/StatusLabel';
 import { connectionPanelContainer } from './ConnectionPanel.styles';
+import { JenkinsServer } from '../../../../src/common/types';
+import { getAllJenkinsServers } from '../../api/getAllJenkinsServers';
+
+// TODO - add DUPLICATE state once I'm pulling in new data from backend
+export const addConnectedState = (servers: JenkinsServer[]): JenkinsServer[] => {
+	return servers.map((server: JenkinsServer) => ({
+		...server,
+		connectedState: server.pipelines.length === 0 ? ConnectedState.PENDING : ConnectedState.CONNECTED
+	}));
+};
 
 const ConnectionPanel = (): JSX.Element => {
-	// TODO - remove temp state and define pending/duplicate/connected state from data
-	const [connectedState, setConnectState] = useState<ConnectedState>(ConnectedState.PENDING);
+	const [jenkinsServers, setJenkinsServers] = useState<JenkinsServer[]>([]);
+
+	const fetchAllJenkinsServers = async () => {
+		const servers = await getAllJenkinsServers() || [];
+		const serversWithConnectedState = addConnectedState(servers);
+		setJenkinsServers(serversWithConnectedState);
+	};
 
 	useEffect(() => {
-		// TODO - update this based on data
-		setConnectState(ConnectedState.DUPLICATE);
+		fetchAllJenkinsServers();
 	}, []);
 
 	return (
-		<div className={cx(connectionPanelContainer)}>
-			<ConnectionPanelTop connectedState={connectedState} ipAddress="10.10.0.10"/>
-			<ConnectionPanelMain connectedState={connectedState} />
-		</div>
+		<>
+			{jenkinsServers.map(
+				(server: JenkinsServer, index: number): JSX.Element => (
+					<div className={cx(connectionPanelContainer)} key={index}>
+						<ConnectionPanelTop connectedState={server.connectedState || ConnectedState.PENDING} ipAddress="10.10.0.10"/>
+						<ConnectionPanelMain
+							connectedState={server.connectedState || ConnectedState.PENDING}
+							jenkinsServers={jenkinsServers}
+						/>
+					</div>
+				)
+			)}
+		</>
 	);
 };
 

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.tsx
@@ -36,7 +36,7 @@ const ConnectionPanel = (): JSX.Element => {
 						<ConnectionPanelTop connectedState={server.connectedState || ConnectedState.PENDING} ipAddress="10.10.0.10"/>
 						<ConnectionPanelMain
 							connectedState={server.connectedState || ConnectedState.PENDING}
-							jenkinsServers={jenkinsServers}
+							jenkinsServer={server}
 						/>
 					</div>
 				)

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelMain.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelMain.tsx
@@ -9,8 +9,6 @@ import {
 import { ConnectedState } from '../StatusLabel/StatusLabel';
 import { NotConnectedState } from './NotConnectedState';
 import { JenkinsServer } from '../../../../src/common/types';
-import { JenkinsSpinner } from '../JenkinsSpinner/JenkinsSpinner';
-import { spinnerHeight } from '../../common/styles/spinner.styles';
 import { ConnectedJenkinsServers } from './ConnectedJenkinsServers';
 import { SetUpGuide } from './SetUpGuide';
 
@@ -49,10 +47,6 @@ type ConnectionPanelMainProps = {
 };
 
 const ConnectionPanelMain = ({ connectedState, jenkinsServer }: ConnectionPanelMainProps): JSX.Element => {
-	if (!jenkinsServer) {
-		return <JenkinsSpinner secondaryClassName={spinnerHeight} />;
-	}
-
 	return (
 		<div className={cx(connectionPanelMainContainer)}>
 			{

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelMain.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelMain.tsx
@@ -1,7 +1,11 @@
 import React, { ReactNode } from 'react';
 import { cx } from '@emotion/css';
 import Tabs, { Tab, TabList, TabPanel } from '@atlaskit/tabs';
-import { connectionPanelMainContainer, connectionPanelMainTabs } from './ConnectionPanel.styles';
+import {
+	connectionPanelMainContainer,
+	connectionPanelMainConnectedTabs,
+	connectionPanelMainNotConnectedTabs
+} from './ConnectionPanel.styles';
 import { ConnectedState } from '../StatusLabel/StatusLabel';
 import { NotConnectedState } from './NotConnectedState';
 import { JenkinsServer } from '../../../../src/common/types';
@@ -9,29 +13,40 @@ import { JenkinsSpinner } from '../JenkinsSpinner/JenkinsSpinner';
 import { spinnerHeight } from '../../common/styles/spinner.styles';
 import { ConnectedJenkinsServers } from './ConnectedJenkinsServers';
 
+// TODO - remove ? for children and connectedState once set up guide is merged
+type PanelProps = {
+	children?: ReactNode,
+	connectedState?: ConnectedState,
+	testId?: string
+};
+
 export const Panel = ({
 	children,
+	connectedState,
 	testId
-}: {
-	children: ReactNode;
-	testId?: string;
-}) => (
-	<div className={cx(connectionPanelMainTabs)} data-testid={testId}>
+}: PanelProps) => (
+	<div
+		className={cx(
+			connectedState === ConnectedState.CONNECTED
+				? connectionPanelMainConnectedTabs
+				: connectionPanelMainNotConnectedTabs
+		)}
+		data-testid={testId}
+	>
 		{children}
 	</div>
 );
 
 type ConnectionPanelMainProps = {
 	connectedState: ConnectedState,
-	jenkinsServers: JenkinsServer[]
+	jenkinsServer: JenkinsServer
 };
 
-const ConnectionPanelMain = ({ connectedState, jenkinsServers }: ConnectionPanelMainProps): JSX.Element => {
-	if (!jenkinsServers) {
+const ConnectionPanelMain = ({ connectedState, jenkinsServer }: ConnectionPanelMainProps): JSX.Element => {
+	if (!jenkinsServer) {
 		return <JenkinsSpinner secondaryClassName={spinnerHeight} />;
 	}
 
-	// TODO - update each server item to include CONNECTED, DUPLICATE, PENDING states
 	return (
 		<div className={cx(connectionPanelMainContainer)}>
 			{
@@ -39,7 +54,7 @@ const ConnectionPanelMain = ({ connectedState, jenkinsServers }: ConnectionPanel
 					? <NotConnectedState connectedState={connectedState} />
 					: <Tabs id="connection-panel-tabs">
 						<TabList>
-							{/* TODO - update (0) for connected state */}
+							{/* TODO - update (0) for connected state with number of pipeline events */}
 							{
 								connectedState === ConnectedState.PENDING
 									? <Tab>Recent events (0)</Tab>
@@ -47,11 +62,12 @@ const ConnectionPanelMain = ({ connectedState, jenkinsServers }: ConnectionPanel
 							}
 							<Tab>Set up guide</Tab>
 						</TabList>
+
 						<TabPanel>
 							{
 								connectedState === ConnectedState.CONNECTED
-									?	<Panel>
-										<ConnectedJenkinsServers connectedJenkinsServers={jenkinsServers} />
+									?	<Panel connectedState={connectedState}>
+										<ConnectedJenkinsServers connectedJenkinsServer={jenkinsServer} />
 									</Panel>
 									: <Panel><NotConnectedState connectedState={connectedState} /></Panel>
 							}

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelMain.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelMain.tsx
@@ -4,7 +4,8 @@ import Tabs, { Tab, TabList, TabPanel } from '@atlaskit/tabs';
 import {
 	connectionPanelMainContainer,
 	connectionPanelMainConnectedTabs,
-	connectionPanelMainNotConnectedTabs, setUpGuideContainer
+	connectionPanelMainNotConnectedTabs,
+	setUpGuideContainer
 } from './ConnectionPanel.styles';
 import { ConnectedState } from '../StatusLabel/StatusLabel';
 import { NotConnectedState } from './NotConnectedState';

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelMain.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelMain.tsx
@@ -4,6 +4,10 @@ import Tabs, { Tab, TabList, TabPanel } from '@atlaskit/tabs';
 import { connectionPanelMainContainer, connectionPanelMainTabs } from './ConnectionPanel.styles';
 import { ConnectedState } from '../StatusLabel/StatusLabel';
 import { NotConnectedState } from './NotConnectedState';
+import { JenkinsServer } from '../../../../src/common/types';
+import { JenkinsSpinner } from '../JenkinsSpinner/JenkinsSpinner';
+import { spinnerHeight } from '../../common/styles/spinner.styles';
+import { ConnectedJenkinsServers } from './ConnectedJenkinsServers';
 
 export const Panel = ({
 	children,
@@ -18,10 +22,16 @@ export const Panel = ({
 );
 
 type ConnectionPanelMainProps = {
-	connectedState: ConnectedState
+	connectedState: ConnectedState,
+	jenkinsServers: JenkinsServer[]
 };
 
-const ConnectionPanelMain = ({ connectedState }: ConnectionPanelMainProps): JSX.Element => {
+const ConnectionPanelMain = ({ connectedState, jenkinsServers }: ConnectionPanelMainProps): JSX.Element => {
+	if (!jenkinsServers) {
+		return <JenkinsSpinner secondaryClassName={spinnerHeight} />;
+	}
+
+	// TODO - update each server item to include CONNECTED, DUPLICATE, PENDING states
 	return (
 		<div className={cx(connectionPanelMainContainer)}>
 			{
@@ -30,13 +40,19 @@ const ConnectionPanelMain = ({ connectedState }: ConnectionPanelMainProps): JSX.
 					: <Tabs id="connection-panel-tabs">
 						<TabList>
 							{/* TODO - update (0) for connected state */}
-							<Tab>Recent events (0)</Tab>
+							{
+								connectedState === ConnectedState.PENDING
+									? <Tab>Recent events (0)</Tab>
+									: <Tab>Recent events (12)</Tab>
+							}
 							<Tab>Set up guide</Tab>
 						</TabList>
 						<TabPanel>
 							{
 								connectedState === ConnectedState.CONNECTED
-									? <Panel>List of servers goes here</Panel>
+									?	<Panel>
+										<ConnectedJenkinsServers connectedJenkinsServers={jenkinsServers} />
+									</Panel>
 									: <Panel><NotConnectedState connectedState={connectedState} /></Panel>
 							}
 						</TabPanel>

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelMain.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelMain.tsx
@@ -65,14 +65,14 @@ const ConnectionPanelMain = ({ connectedState, jenkinsServer }: ConnectionPanelM
 						<TabPanel>
 							{
 								connectedState === ConnectedState.CONNECTED
-									?	<Panel connectedState={connectedState} testId="connectedServersPanel">
+									?	<Panel connectedState={connectedState} data-testid="connectedServersPanel">
 										<ConnectedJenkinsServers connectedJenkinsServer={jenkinsServer} />
 									</Panel>
-									: <Panel testId="notConnectedPanel"><NotConnectedState connectedState={connectedState} /></Panel>
+									: <Panel data-testid="notConnectedPanel"><NotConnectedState connectedState={connectedState} /></Panel>
 							}
 						</TabPanel>
 						<TabPanel>
-							<Panel testId="setUpGuidePanel">
+							<Panel data-testid="setUpGuidePanel">
 								<SetUpGuide />
 							</Panel>
 						</TabPanel>

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelTop.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelTop.tsx
@@ -14,7 +14,8 @@ import { ConnectedState, StatusLabel } from '../StatusLabel/StatusLabel';
 
 type ConnectionPanelTopProps = {
 	connectedState: ConnectedState,
-	ipAddress: string
+	ipAddress: string,
+	name: string
 };
 
 const connectedStateColors: Record<ConnectedState, { textColor: string; backgroundColor: string }> = {
@@ -23,14 +24,14 @@ const connectedStateColors: Record<ConnectedState, { textColor: string; backgrou
 	[ConnectedState.PENDING]: { textColor: '#a54900', backgroundColor: '#fff7d6' }
 };
 
-const ConnectionPanelTop = ({ connectedState, ipAddress }: ConnectionPanelTopProps): JSX.Element => {
+const ConnectionPanelTop = ({ connectedState, ipAddress, name }: ConnectionPanelTopProps): JSX.Element => {
 	const { textColor, backgroundColor } = connectedStateColors[connectedState];
 
 	return (
 		<div className={cx(connectionPanelTopContainer)}>
 			<div className={cx(connectionPanelHeaderContainer)}>
 				<div className={cx(connectionPanelHeaderContentContainer)}>
-					<h2 className={cx(serverName)}>Insert name</h2>
+					<h2 className={cx(serverName)}>{name}</h2>
 					<StatusLabel text={connectedState} color={textColor} backgroundColor={backgroundColor} />
 				</div>
 				<div>

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/SetUpGuide.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/SetUpGuide.tsx
@@ -10,7 +10,8 @@ import {
 	setUpGuideOrderedList,
 	setUpGuideOrderedListItem,
 	setUpGuideOrderListItemHeader,
-	setUpGuideParagraph, setUpGuideContainer
+	setUpGuideParagraph,
+	setUpGuideContainer
 } from './ConnectionPanel.styles';
 
 type SetUpGuideLinkProps = {

--- a/app/jenkins-for-jira-ui/src/components/MainPage/MainPage.tsx
+++ b/app/jenkins-for-jira-ui/src/components/MainPage/MainPage.tsx
@@ -19,7 +19,7 @@ const MainPage = (): JSX.Element => {
 		</ButtonGroup>
 	);
 
-	// TODO - if there are no servers, render connection wizard instead of toppanl + connection panel
+	// TODO - if there are no servers, render connection wizard instead of toppanel + connection panel
 	return (
 		<div className={mainPageContainer}>
 			<div className={headerContainer}>

--- a/app/src/common/types.ts
+++ b/app/src/common/types.ts
@@ -7,12 +7,19 @@ export enum EventType {
 	DEPLOYMENT = 'deployment'
 }
 
+export enum ConnectedState {
+	CONNECTED = 'CONNECTED',
+	DUPLICATE = 'DUPLICATE',
+	PENDING = 'PENDING'
+}
+
 export interface JenkinsServer {
 	uuid: string,
 	name: string,
 	secret?: string,
 	pipelines: JenkinsPipeline[],
 	pluginConfig?: JenkinsPluginConfig;
+	connectedState?: ConnectedState
 }
 
 export interface JenkinsPipeline {

--- a/app/src/common/types.ts
+++ b/app/src/common/types.ts
@@ -18,7 +18,7 @@ export interface JenkinsServer {
 	name: string,
 	secret?: string,
 	pipelines: JenkinsPipeline[],
-	pluginConfig?: JenkinsPluginConfig;
+	pluginConfig?: JenkinsPluginConfig,
 	connectedState?: ConnectedState
 }
 


### PR DESCRIPTION
**What's in this PR?**
Connected state component that will be used in both the admin and global pages.

If a pipeline ran within the last 24 hours you'll see the time formatted like:

![Screenshot 2023-11-22 at 10 42 15 am](https://github.com/atlassian/jenkins-for-jira/assets/37155488/f4774f55-3a15-497a-9e2a-bdbb0deaa7f6)

Otherwise, it will look like:

![Screenshot 2023-11-22 at 10 42 07 am](https://github.com/atlassian/jenkins-for-jira/assets/37155488/72ffad1d-4cd4-4b15-aad0-f4527b02d992)

**Why**
Coz it wasn't done yet?

**Added feature flags**
All behind RENOVATED_JENKINS_FOR_JIRA_CONFIG_FLOW

**Affected issues**  
Arc-2676

**How has this been tested?**  
Locally and staging

**What's Next?**
* Consume data from the backend, update existing dummy data, and write tests for set up guide (didn't do it when I created the set up guide component as I would have to change the tests once real data was flowing in)
* A loader will be added when I build the connection wizard for the empty state