### PR TITLE
add browser none to stop tab from opening

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -44,7 +44,7 @@ To get up and running, follow the steps below.
 
 #### Initial setup
 
-1. Create your `.env` file based on the `.env.example` file in **/app/jenkins-for-jira-ui**.
+1. Create your `.env` file and add `BROWSER=none`. This will prevent a tab opening at http:localhost:3000 when you run `yarn start`.
 2. Switch to the correct `node` version. You can run `nvm use` in the folders: **/app/jenkins-for-jira-ui** and **/app**.
 3. In the folders **/app** and **/app/jenkins-for-jira-ui**, run `yarn install`.
 

--- a/app/jenkins-for-jira-ui/.gitignore
+++ b/app/jenkins-for-jira-ui/.gitignore
@@ -1,1 +1,2 @@
+.env
 .env.local


### PR DESCRIPTION
**What's in this PR?**
Added browser none to env vars to stop this stupid tab from opening every time we spin up the frontend.

https://github.com/atlassian/jenkins-for-jira/assets/37155488/30696e08-092e-495a-8858-f8fe99d932f4

Oh and ripped out .env.example coz it was empty. Probably not the best example for any wannabe contributors.

**Why**
I think the question here should be: 'why didn't you do this sooner?' 

**How has this been tested?**  
Locally... coz that's the only place it happens... :awkward_sus:

**What's Next?**
Back to actual work.