### PR TITLE
Arc-2595 server name screen

### DIFF
--- a/app/jenkins-for-jira-ui/src/App.tsx
+++ b/app/jenkins-for-jira-ui/src/App.tsx
@@ -6,9 +6,8 @@ import {
 } from 'react-router';
 import styled from '@emotion/styled';
 import { view } from '@forge/bridge';
-import { token } from '@atlaskit/tokens';
+import { token, setGlobalTheme } from '@atlaskit/tokens';
 import { withLDProvider } from 'launchdarkly-react-client-sdk';
-import { setGlobalTheme } from '@atlaskit/tokens';
 import { InstallJenkins } from './components/ConnectJenkins/InstallJenkins/InstallJenkins';
 import { JenkinsServerList } from './components/JenkinsServerList/JenkinsServerList';
 import { ConnectJenkins } from './components/ConnectJenkins/ConnectJenkins/ConnectJenkins';
@@ -21,6 +20,7 @@ import envVars, { Environment } from './common/env';
 import { fetchFeatureFlagFromBackend } from './api/fetchFeatureFlagFromBackend';
 import { FeatureFlags } from './hooks/useFeatureFlag';
 import { ServerManagement } from './components/ServerManagement/ServerManagement';
+import { ServerNameForm } from './components/ServerNameForm/ServerNameForm';
 
 const {
 	LAUNCHDARKLY_TEST_CLIENT_ID,
@@ -114,6 +114,8 @@ const App: React.FC = () => {
 							: <JenkinsServerList />
 						}
 					</Route>
+
+					{/* TODO - delete routes for old version post renovate rollout */}
 					<Route path="/install">
 						<InstallJenkins />
 					</Route>
@@ -128,6 +130,10 @@ const App: React.FC = () => {
 					</Route>
 					<Route path="/pending/:id">
 						<PendingDeploymentState />
+					</Route>
+
+					<Route path="/server-name">
+						<ServerNameForm />
 					</Route>
 				</Switch>
 			</Router>

--- a/app/jenkins-for-jira-ui/src/App.tsx
+++ b/app/jenkins-for-jira-ui/src/App.tsx
@@ -132,7 +132,7 @@ const App: React.FC = () => {
 						<PendingDeploymentState />
 					</Route>
 
-					<Route path="/server-name">
+					<Route path="/create-server">
 						<ServerNameForm />
 					</Route>
 				</Switch>

--- a/app/jenkins-for-jira-ui/src/GlobalStyles.styles.tsx
+++ b/app/jenkins-for-jira-ui/src/GlobalStyles.styles.tsx
@@ -68,3 +68,13 @@ export const infoPanel = css`
 export const connectionWizardInfoPanelInstruction = css`
 	margin-bottom: ${token('space.400')};
 `;
+
+export const connectionFlowContainer = css`
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	height: 100vh;
+	justify-content: center;
+	margin: ${token('space.negative.400')} auto;
+	width: 360px;
+`;

--- a/app/jenkins-for-jira-ui/src/common/util/jenkinsConnectionsUtils.ts
+++ b/app/jenkins-for-jira-ui/src/common/util/jenkinsConnectionsUtils.ts
@@ -12,6 +12,26 @@ export const setName = async (event: React.ChangeEvent<HTMLInputElement>, setSer
 	setServerName(event.target.value);
 };
 
+export const isValid = (
+	value: string,
+	setErrorMessage: {
+		(value: SetStateAction<string>): void; (value: SetStateAction<string>): void; (arg0: string): void;
+	}
+): boolean => {
+	if (!value) {
+		setErrorMessage('This field is required.');
+		return false;
+	}
+
+	if (value.length > 100) {
+		setErrorMessage('Server name exceeds 100 characters. Choose a shorter server name and try again.');
+		return false;
+	}
+
+	setErrorMessage('');
+	return true;
+};
+
 export const isFormValid = (
 	value: string,
 	setHasError: {

--- a/app/jenkins-for-jira-ui/src/common/util/jenkinsConnectionsUtils.ts
+++ b/app/jenkins-for-jira-ui/src/common/util/jenkinsConnectionsUtils.ts
@@ -12,6 +12,7 @@ export const setName = async (event: React.ChangeEvent<HTMLInputElement>, setSer
 	setServerName(event.target.value);
 };
 
+// TODO kill off isFormValid when rollout is complete
 export const isValid = (
 	value: string,
 	setErrorMessage: {

--- a/app/jenkins-for-jira-ui/src/common/util/jenkinsConnectionsUtils.ts
+++ b/app/jenkins-for-jira-ui/src/common/util/jenkinsConnectionsUtils.ts
@@ -13,7 +13,7 @@ export const setName = async (event: React.ChangeEvent<HTMLInputElement>, setSer
 };
 
 // TODO kill off isFormValid when rollout is complete
-export const isValid = (
+export const isValidServerName = (
 	value: string,
 	setErrorMessage: {
 		(value: SetStateAction<string>): void; (value: SetStateAction<string>): void; (arg0: string): void;

--- a/app/jenkins-for-jira-ui/src/components/ConnectionWizard/ConnectionFlowHeader.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionWizard/ConnectionFlowHeader.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { cx } from '@emotion/css';
+import { JenkinsSyncJiraIcon } from '../icons/JenkinsSyncJiraIcon';
+import { connectionWizardHeader } from './ConnectionWizard.styles';
+
+const ConnectionFlowHeader = (): JSX.Element => {
+	return (
+		<>
+			<JenkinsSyncJiraIcon />
+			<h3 className={cx(connectionWizardHeader)}>Connect Jenkins to Jira</h3>
+		</>
+	);
+};
+
+export { ConnectionFlowHeader };

--- a/app/jenkins-for-jira-ui/src/components/ConnectionWizard/ConnectionWizard.styles.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionWizard/ConnectionWizard.styles.tsx
@@ -1,16 +1,6 @@
 import { css } from '@emotion/css';
 import { token } from '@atlaskit/tokens';
 
-export const connectionWizardContainer = css`
-	align-items: center;
-	display: flex;
-	flex-direction: column;
-	height: 100vh;
-	justify-content: center;
-	margin: ${token('space.negative.400')} auto;
-	width: 360px;
-`;
-
 export const connectionWizardContentContainer = css`
 	margin-left: ${token('space.negative.400')};
 	width: 100%;

--- a/app/jenkins-for-jira-ui/src/components/ConnectionWizard/ConnectionWizard.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionWizard/ConnectionWizard.tsx
@@ -27,7 +27,7 @@ const ConnectionWizard = (): JSX.Element => {
 
 	const handleNavigateToServerNameScreen = (e: React.MouseEvent) => {
 		e.preventDefault();
-		history.push('/server-name');
+		history.push('/create-server');
 	};
 
 	return (

--- a/app/jenkins-for-jira-ui/src/components/ConnectionWizard/ConnectionWizard.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionWizard/ConnectionWizard.tsx
@@ -3,9 +3,8 @@ import { cx } from '@emotion/css';
 import Button from '@atlaskit/button';
 import PeopleGroup from '@atlaskit/icon/glyph/people-group';
 import ArrowRightIcon from '@atlaskit/icon/glyph/arrow-right';
+import { useHistory } from 'react-router';
 import {
-	connectionWizardContainer,
-	connectionWizardHeader,
 	connectionWizardInfoPanel,
 	connectionWizardNestedOrderedListItem,
 	connectionWizardOrderedListItem,
@@ -15,21 +14,26 @@ import {
 	connectionWizardInfoPaneIphLink
 } from './ConnectionWizard.styles';
 import {
-	infoPanel, orderedList, orderedListItem
+	connectionFlowContainer,
+	infoPanel,
+	orderedList,
+	orderedListItem
 } from '../../GlobalStyles.styles';
 import { InProductHelpAction, InProductHelpActionType } from '../InProductHelpDrawer/InProductHelpAction';
-import { JenkinsSyncJiraIcon } from '../icons/JenkinsSyncJiraIcon';
+import { ConnectionFlowHeader } from './ConnectionFlowHeader';
 
 const ConnectionWizard = (): JSX.Element => {
+	const history = useHistory();
+
 	const handleNavigateToServerNameScreen = (e: React.MouseEvent) => {
 		e.preventDefault();
-		// TODO - add onclick in build new server name
+		history.push('/server-name');
 	};
 
 	return (
-		<div className={cx(connectionWizardContainer)} data-testid="connection-wizard">
-			<JenkinsSyncJiraIcon />
-			<h3 className={cx(connectionWizardHeader)}>Connect Jenkins to Jira</h3>
+		<div className={cx(connectionFlowContainer)} data-testid="connection-wizard">
+			<ConnectionFlowHeader />
+
 			<div className={cx(connectionWizardContentContainer)}>
 				<p>To complete this connection you'll need:</p>
 

--- a/app/jenkins-for-jira-ui/src/components/ServerManagement/ServerManagement.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ServerManagement/ServerManagement.tsx
@@ -160,7 +160,7 @@ const ServerManagement = (): JSX.Element => {
 
 	const handleNavigateToServerNameScreen = (e: React.MouseEvent) => {
 		e.preventDefault();
-		history.push('/server-name');
+		history.push('/create-server');
 	};
 
 	const pageHeaderActions = (

--- a/app/jenkins-for-jira-ui/src/components/ServerManagement/ServerManagement.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ServerManagement/ServerManagement.tsx
@@ -7,6 +7,7 @@ import { ButtonGroup } from '@atlaskit/button';
 import Button from '@atlaskit/button/standard-button';
 import { cx } from '@emotion/css';
 import TextArea from '@atlaskit/textarea';
+import { useHistory } from 'react-router';
 import { headerContainer } from '../JenkinsServerList/JenkinsServerList.styles';
 import { serverManagementContainer, shareModalInstruction } from './ServerManagement.styles';
 import { addConnectedState, ConnectionPanel } from '../ConnectionPanel/ConnectionPanel';
@@ -88,6 +89,7 @@ export const contentToRenderServerManagementScreen = (
 };
 
 const ServerManagement = (): JSX.Element => {
+	const history = useHistory();
 	const [jenkinsServers, setJenkinsServers] = useState<JenkinsServer[]>([]);
 	const [moduleKey, setModuleKey] = useState<string>();
 	const [showSharePage, setshowSharePage] = useState<boolean>(false);
@@ -156,10 +158,19 @@ const ServerManagement = (): JSX.Element => {
 		};
 	}, [redirectToAdminPage]);
 
+	const handleNavigateToServerNameScreen = (e: React.MouseEvent) => {
+		e.preventDefault();
+		history.push('/server-name');
+	};
+
 	const pageHeaderActions = (
 		<ButtonGroup>
-			{/* TODO handle empty state - ARC-2730 connection wizard */}
-			<Button appearance="primary">Connect a new Jenkins server</Button>
+			<Button
+				appearance="primary"
+				onClick={(e) => handleNavigateToServerNameScreen(e)}
+			>
+				Connect a new Jenkins server
+			</Button>
 			<Button onClick={() => handleShowSharePageModal()}>Share page</Button>
 		</ButtonGroup>
 	);

--- a/app/jenkins-for-jira-ui/src/components/ServerNameForm/ServerNameForm.styles.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ServerNameForm/ServerNameForm.styles.tsx
@@ -1,0 +1,12 @@
+import { css } from '@emotion/css';
+import { token } from '@atlaskit/tokens';
+
+export const serverNameFormOuterContainer = css`
+	border: 2px solid #dee0e4;
+	width: 580px;
+`;
+
+export const serverNameFormInnerContainer = css`
+	margin: ${token('space.400')} auto;
+	width: 420px;
+`;

--- a/app/jenkins-for-jira-ui/src/components/ServerNameForm/ServerNameForm.test.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ServerNameForm/ServerNameForm.test.tsx
@@ -43,6 +43,4 @@ describe('ServerNameForm', () => {
 
 		expect(getByText('This field is required.')).toBeInTheDocument();
 	});
-
-	// Add more tests for edge cases, error handling, etc.
 });

--- a/app/jenkins-for-jira-ui/src/components/ServerNameForm/ServerNameForm.test.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ServerNameForm/ServerNameForm.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { ServerNameForm } from './ServerNameForm';
+
+describe('ServerNameForm', () => {
+	it('renders form elements correctly', () => {
+		const { getByLabelText, getByText } = render(<ServerNameForm />);
+
+		expect(getByLabelText('server name field')).toBeInTheDocument();
+		expect(getByText('Give your Jenkins server a name.', { exact: false })).toBeInTheDocument();
+		expect(getByText('Next')).toBeInTheDocument();
+	});
+
+	it('handles server name input change correctly', () => {
+		const { getByLabelText } = render(<ServerNameForm />);
+		const serverNameInput = getByLabelText('server name field') as HTMLInputElement;
+
+		fireEvent.change(serverNameInput, { target: { value: 'MyServer' } });
+
+		expect(serverNameInput.value).toBe('MyServer');
+	});
+
+	it('submits the form correctly on valid input', async () => {
+		const { getByLabelText, getByTestId, queryByTestId } = render(<ServerNameForm />);
+		const serverNameInput = getByLabelText('server name field');
+
+		fireEvent.change(serverNameInput, { target: { value: 'MyServer' } });
+		fireEvent.submit(getByTestId('createServerForm'));
+
+		expect(getByTestId('loading-button')).toBeInTheDocument();
+
+		await waitFor(() => {});
+
+		expect(queryByTestId('loading-button')).toBeNull();
+	});
+
+	it('displays error message on invalid input', async () => {
+		const { getByLabelText, getByTestId, getByText } = render(<ServerNameForm />);
+		const serverNameInput = getByLabelText('server name field');
+
+		fireEvent.change(serverNameInput, { target: { value: '' } });
+		fireEvent.submit(getByTestId('createServerForm'));
+
+		expect(getByText('This field is required.')).toBeInTheDocument();
+	});
+
+	// Add more tests for edge cases, error handling, etc.
+});

--- a/app/jenkins-for-jira-ui/src/components/ServerNameForm/ServerNameForm.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ServerNameForm/ServerNameForm.tsx
@@ -7,7 +7,7 @@ import Form, {
 } from '@atlaskit/form';
 import { v4 as uuidv4 } from 'uuid';
 import Textfield from '@atlaskit/textfield';
-import { isValid } from '../../common/util/jenkinsConnectionsUtils';
+import { isValidServerName } from '../../common/util/jenkinsConnectionsUtils';
 import { connectionFlowContainer 	} from '../../GlobalStyles.styles';
 import { ConnectionFlowHeader } from '../ConnectionWizard/ConnectionFlowHeader';
 import { createJenkinsServer } from '../../api/createJenkinsServer';
@@ -90,7 +90,7 @@ const ServerNameForm = (): JSX.Element => {
 	};
 
 	const handleSubmitCreateServer = async () => {
-		if (isValid(serverName, setErrorMessage)) {
+		if (isValidServerName(serverName, setErrorMessage)) {
 			setIsLoading(true);
 			const uuid = uuidv4();
 

--- a/app/jenkins-for-jira-ui/src/components/ServerNameForm/ServerNameForm.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ServerNameForm/ServerNameForm.tsx
@@ -1,0 +1,168 @@
+import React, { useState } from 'react';
+import { cx } from '@emotion/css';
+import LoadingButton from '@atlaskit/button/loading-button';
+import Button from '@atlaskit/button/standard-button';
+import Form, {
+	ErrorMessage, Field, FormFooter, HelperMessage
+} from '@atlaskit/form';
+import { v4 as uuidv4 } from 'uuid';
+import Textfield from '@atlaskit/textfield';
+import { isValid } from '../../common/util/jenkinsConnectionsUtils';
+import { connectionFlowContainer 	} from '../../GlobalStyles.styles';
+import { ConnectionFlowHeader } from '../ConnectionWizard/ConnectionFlowHeader';
+import { createJenkinsServer } from '../../api/createJenkinsServer';
+import { generateNewSecret } from '../../api/generateNewSecret';
+import {
+	loadingIcon,
+	StyledTextfieldErrorContainer,
+	textfieldContainer
+} from '../JenkinsConfigurationForm/JenkinsConfigurationForm.styles';
+import { serverNameFormOuterContainer, serverNameFormInnerContainer } from './ServerNameForm.styles';
+import { getAllJenkinsServers } from '../../api/getAllJenkinsServers';
+import { JenkinsServer } from '../../../../src/common/types';
+
+const jenkinsServerNameExists = (servers: JenkinsServer[], serverName: string): boolean => {
+	return servers.some((server: JenkinsServer) => server.name === serverName);
+};
+
+type ServerNameFormFieldProps = {
+	serverName: string,
+	setServerName: (event: React.ChangeEvent<HTMLInputElement>) => void,
+	serverNameHelperText?: string,
+	hasError: boolean,
+	errorMessage?: string
+};
+
+const ServerNameFormField = ({
+	serverName,
+	setServerName,
+	serverNameHelperText = '',
+	hasError,
+	errorMessage
+}: ServerNameFormFieldProps) => {
+	return (
+		<>
+			<StyledTextfieldErrorContainer hasError={hasError}>
+				<Field label='Server name' name='server-name-label' isRequired>
+					{() => (
+						<>
+							<div className={textfieldContainer}>
+								<Textfield
+									name='server-name'
+									value={serverName}
+									aria-label='server name field'
+									testId='server-name'
+									onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+										setServerName(event);
+									}}
+								/>
+							</div>
+
+							<HelperMessage>
+								{serverNameHelperText}
+							</HelperMessage>
+						</>
+					)}
+				</Field>
+				{ hasError && (
+					<ErrorMessage testId='error-message'>
+						{errorMessage}
+					</ErrorMessage>
+				)}
+			</StyledTextfieldErrorContainer>
+		</>
+	);
+};
+
+const ServerNameForm = (): JSX.Element => {
+	const [serverName, setServerName] = useState('');
+	const [errorMessage, setErrorMessage] = useState('');
+	const [isLoading, setIsLoading] = useState(false);
+
+	const setServerNameHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+		const newServerName = event.target.value;
+
+		if (!!errorMessage && newServerName.length > 0) {
+			setErrorMessage('');
+		}
+
+		setServerName(newServerName);
+	};
+
+	const handleSubmitCreateServer = async () => {
+		if (isValid(serverName, setErrorMessage)) {
+			setIsLoading(true);
+			const uuid = uuidv4();
+
+			const servers = await getAllJenkinsServers() || [];
+			const serverExists = jenkinsServerNameExists(servers, serverName);
+
+			if (serverExists) {
+				setErrorMessage('This name is already in use. Choose a unique name.');
+				setIsLoading(false);
+				return;
+			}
+
+			try {
+				await createJenkinsServer({
+					name: serverName,
+					uuid,
+					secret: await generateNewSecret(),
+					pipelines: []
+				});
+
+				setIsLoading(false);
+				// TODO - add history.push to /setup ARC-2596
+			} catch (e) {
+				console.error('Error: ', e);
+				setIsLoading(false);
+			}
+		}
+	};
+
+	const submitButtonIsDisabled = !serverName.length || !!errorMessage.length;
+
+	return (
+		<div className={cx(connectionFlowContainer)}>
+			<ConnectionFlowHeader />
+
+			<div className={cx(serverNameFormOuterContainer)}>
+				<div className={cx(serverNameFormInnerContainer)}>
+
+					<h3>Get started</h3>
+					<p>Give your Jenkins server a name. We'll use this as a display name in
+					Jira to keep track of your connection.</p>
+
+					<Form onSubmit={handleSubmitCreateServer}>
+						{({ formProps }: any) => (
+							<form {...formProps} name='create-server-form' data-testid="createServerForm">
+								<ServerNameFormField
+									serverName={serverName}
+									setServerName={setServerNameHandler}
+									hasError={!!errorMessage}
+									errorMessage={errorMessage}
+								/>
+
+								<FormFooter align="start">
+									{isLoading
+										? <LoadingButton appearance='primary' isLoading className={loadingIcon} testId='loading-button' />
+										: <Button
+											type='submit'
+											appearance='primary'
+											isDisabled={submitButtonIsDisabled}
+											testId='submit-button'
+										>
+										Next
+										</Button>
+									}
+								</FormFooter>
+							</form>
+						)}
+					</Form>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export { ServerNameForm };


### PR DESCRIPTION
**What's in this PR?**
Server name screen: empty state when there are no servers/connect a new server from configured screen.

Input empty (disabled button)
![Screenshot 2024-01-04 at 10 48 46 am](https://github.com/atlassian/jenkins-for-jira/assets/37155488/0f96ac62-4429-417b-ac51-c4510bbfd2e1)

Input added (button active)
![Screenshot 2024-01-04 at 10 46 33 am](https://github.com/atlassian/jenkins-for-jira/assets/37155488/48221035-dd36-4797-b9b0-cfd69f939cae)

Error state (new check to see if the server name already exists)
![Screenshot 2024-01-04 at 10 44 38 am](https://github.com/atlassian/jenkins-for-jira/assets/37155488/a614d68d-18e9-47eb-983f-fa10051e4627)

**Why**
So users can create servers from an empty/configured state

**Added feature flags**
same as always

**Affected issues**  
Arc-2595

**How has this been tested?**  
Locally, tests, stg

**What's Next?**
The next screen :hyperblob: