### PR TITLE
None fix more shit

### DIFF
--- a/app/jenkins-for-jira-ui/package.json
+++ b/app/jenkins-for-jira-ui/package.json
@@ -33,6 +33,7 @@
     "@emotion/styled": "11.6.0",
     "@forge/bridge": "2.6.0",
     "@forge/ui": "0.16.0",
+    "@types/lodash": "^4.14.202",
     "@types/react": "17.0.65",
     "@types/react-dom": "17.0.20",
     "@types/react-router": "5.1.20",

--- a/app/jenkins-for-jira-ui/src/App.tsx
+++ b/app/jenkins-for-jira-ui/src/App.tsx
@@ -143,7 +143,7 @@ const App: React.FC = () => {
 					<Route path="/update-server-name/:id">
 						<ServerNameForm />
 					</Route>
-					<Route path="/setup/:id">
+					<Route path="/setup/:id/:settings">
 						<JenkinsSetup />
 					</Route>
 					<Route path="/connection-complete/:id/:admin">

--- a/app/jenkins-for-jira-ui/src/components/ConnectJenkins/ConnectJenkins/ConnectJenkins.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectJenkins/ConnectJenkins/ConnectJenkins.tsx
@@ -20,6 +20,7 @@ import { AnalyticsClient } from '../../../common/analytics/analytics-client';
 export interface ParamTypes {
 	id: string;
 	admin: string;
+	settings: string;
 }
 
 const analyticsClient = new AnalyticsClient();

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.test.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.test.tsx
@@ -113,7 +113,14 @@ describe('Connection Panel Suite', () => {
 	test('fetches and displays servers on mount', async () => {
 		jest.spyOn(getAllJenkinsServersModule, 'getAllJenkinsServers').mockResolvedValueOnce(servers);
 
-		render(<ConnectionPanel jenkinsServers={servers} setJenkinsServers={jest.fn()} />);
+		render(<ConnectionPanel
+			jenkinsServers={servers}
+			setJenkinsServers={jest.fn()}
+			isUpdatingServer={false}
+			uuidOfRefreshServer='198219dnq9fn1293r12'
+			updatedServer={undefined}
+			handleRefreshUpdateServer={jest.fn()}
+		/>);
 
 		await waitFor(() => {
 			expect(screen.getByText(servers[0].name)).toBeInTheDocument();

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.tsx
@@ -67,7 +67,6 @@ type ConnectionPanelProps = {
 };
 
 const ConnectionPanel = ({ jenkinsServers, setJenkinsServers }: ConnectionPanelProps): JSX.Element => {
-	const [isLoading, setIsLoading] = useState(false);
 	const [updatedServer, setUpdatedServer] = useState<JenkinsServer>();
 	const [isUpdatingServer, setIsUpdatingServer] = useState<boolean>(false);
 	const [uuidOfRefreshServer, setUuidOfRefreshServer] = useState<string>('');
@@ -112,8 +111,6 @@ const ConnectionPanel = ({ jenkinsServers, setJenkinsServers }: ConnectionPanelP
 								jenkinsServer={server}
 								refreshServers={handleServerRefresh}
 								handleRefreshUpdateServer={handleRefreshUpdateServer}
-								isLoading={isLoading}
-								setIsLoading={setIsLoading}
 								updatedServer={updatedServer}
 								isUpdatingServer={isUpdatingServer}
 								uuidOfRefreshServer={uuidOfRefreshServer}

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanel.tsx
@@ -1,11 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { cx } from '@emotion/css';
 import { ConnectionPanelMain } from './ConnectionPanelMain';
 import { ConnectionPanelTop } from './ConnectionPanelTop';
 import { ConnectedState } from '../StatusLabel/StatusLabel';
 import { connectionPanelContainer } from './ConnectionPanel.styles';
 import { JenkinsServer } from '../../../../src/common/types';
-import { getJenkinsServerWithSecret } from '../../api/getJenkinsServerWithSecret';
 
 export const addConnectedState = (servers: JenkinsServer[]): JenkinsServer[] => {
 	const ipAddressSet = new Set<string>();
@@ -45,54 +44,28 @@ export const addConnectedState = (servers: JenkinsServer[]): JenkinsServer[] => 
 		});
 };
 
-const addConnectedStateToSingleServer = (singleServer: JenkinsServer, allServers: JenkinsServer[]): JenkinsServer => {
-	const ipAddress = singleServer.pluginConfig?.ipAddress;
-
-	const isDuplicate =
-		ipAddress &&
-		allServers.some((server: JenkinsServer) =>
-			server !== singleServer && server.pluginConfig?.ipAddress === ipAddress);
-
-	const connectedState: ConnectedState = isDuplicate ? ConnectedState.DUPLICATE : ConnectedState.CONNECTED;
-
-	return {
-		...singleServer,
-		connectedState
-	};
-};
-
 type ConnectionPanelProps = {
 	jenkinsServers: JenkinsServer[],
-	setJenkinsServers(updatedServers: JenkinsServer[]): void
+	setJenkinsServers(updatedServers: JenkinsServer[]): void,
+	updatedServer: JenkinsServer | undefined,
+	isUpdatingServer: boolean,
+	uuidOfRefreshServer: string,
+	handleRefreshUpdateServer(uuid: string): void
 };
 
-const ConnectionPanel = ({ jenkinsServers, setJenkinsServers }: ConnectionPanelProps): JSX.Element => {
-	const [updatedServer, setUpdatedServer] = useState<JenkinsServer>();
-	const [isUpdatingServer, setIsUpdatingServer] = useState<boolean>(false);
-	const [uuidOfRefreshServer, setUuidOfRefreshServer] = useState<string>('');
-
+const ConnectionPanel = ({
+	jenkinsServers,
+	setJenkinsServers,
+	updatedServer,
+	isUpdatingServer,
+	uuidOfRefreshServer,
+	handleRefreshUpdateServer
+}: ConnectionPanelProps): JSX.Element => {
 	const handleServerRefresh = (serverToRemove: JenkinsServer) => {
 		const refreshedServers = jenkinsServers.filter(
 			(server) => server.uuid !== serverToRemove.uuid
 		);
 		setJenkinsServers(refreshedServers);
-	};
-
-	const handleRefreshUpdateServer = async (uuid: string) => {
-		setIsUpdatingServer(true);
-		setUuidOfRefreshServer(uuid);
-
-		try {
-			const server = await getJenkinsServerWithSecret(uuid);
-
-			if (server.pluginConfig) {
-				setUpdatedServer(addConnectedStateToSingleServer(server, jenkinsServers));
-			}
-
-			setIsUpdatingServer(false);
-		} catch (e) {
-			console.error('No Jenkins server found.');
-		}
 	};
 
 	return (

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelContent.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelContent.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { cx } from '@emotion/css';
 import Button, { Appearance, ButtonGroup } from '@atlaskit/button';
-import Spinner from '@atlaskit/spinner';
 import { ConnectedState } from '../StatusLabel/StatusLabel';
 import {
 	connectionPanelContainerContainer,
 	connectionPanelContainerHeader,
-	connectionPanelContainerParagraph,
-	notConnectedSpinnerContainer
+	connectionPanelContainerParagraph
 } from './ConnectionPanel.styles';
 import { ConnectionPendingIcon } from '../icons/ConnectionPendingIcon';
 import { NoDataIcon } from '../icons/NoDataIcon';
@@ -25,8 +23,8 @@ type NotConnectedStateProps = {
 	buttonOneOnClick(data?: any): void,
 	buttonTwoOnClick?(data: any): void,
 	testId?: string,
-	isLoading: boolean,
-	isIph?: boolean
+	isIph?: boolean,
+	jenkinsServerUuid?: string
 };
 
 const ConnectionPanelContent = ({
@@ -40,8 +38,8 @@ const ConnectionPanelContent = ({
 	buttonOneOnClick,
 	buttonTwoOnClick,
 	testId,
-	isLoading,
-	isIph
+	isIph,
+	jenkinsServerUuid
 }: NotConnectedStateProps): JSX.Element => {
 	let icon;
 
@@ -62,37 +60,31 @@ const ConnectionPanelContent = ({
 				type={InProductHelpActionType.HelpButton}
 			/>;
 	} else {
-		secondaryButton = <Button onClick={buttonTwoOnClick}>{secondButtonLabel}</Button>;
+		secondaryButton =
+			buttonTwoOnClick &&
+			<Button onClick={() => buttonTwoOnClick?.(jenkinsServerUuid)}>{secondButtonLabel}</Button>;
 	}
 
 	return (
 		<div className={cx(connectionPanelContainerContainer)}>
-			{
-				isLoading
-					? <div className={cx(notConnectedSpinnerContainer)}>
-						<Spinner size='large' />
-					</div>
-					: <>
-						{icon}
-						<h3 className={cx(connectionPanelContainerHeader)}>{contentHeader}</h3>
-						<p className={cx(connectionPanelContainerParagraph)}>{contentInstructionOne}</p>
-						<p className={cx(connectionPanelContainerParagraph)}>{contentInstructionTwo}</p>
-						<ButtonGroup>
-							<Button
-								appearance={buttonAppearance}
-								onClick={buttonOneOnClick}
-								testId={testId}
-							>
-								{firstButtonLabel}
-							</Button>
-							{
-								secondButtonLabel
-									? <>{secondaryButton}</>
-									: <></>
-							}
-						</ButtonGroup>
-					</>
-			}
+			{icon}
+			<h3 className={cx(connectionPanelContainerHeader)}>{contentHeader}</h3>
+			<p className={cx(connectionPanelContainerParagraph)}>{contentInstructionOne}</p>
+			<p className={cx(connectionPanelContainerParagraph)}>{contentInstructionTwo}</p>
+			<ButtonGroup>
+				<Button
+					appearance={buttonAppearance}
+					onClick={buttonOneOnClick}
+					testId={testId}
+				>
+					{firstButtonLabel}
+				</Button>
+				{
+					secondButtonLabel
+						? <>{secondaryButton}</>
+						: <></>
+				}
+			</ButtonGroup>
 		</div>
 	);
 };

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelTop.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelTop.tsx
@@ -24,22 +24,6 @@ const connectedStateColors: Record<ConnectedState, { textColor: string; backgrou
 	[ConnectedState.UPDATE_AVAILABLE]: { textColor: '#0054cb', backgroundColor: '#e8f2ff' }
 };
 
-const setConnectedState = (
-	server: JenkinsServer,
-	isUpdatingServer: boolean,
-	updatedServer?: JenkinsServer
-): ConnectedState => {
-	let connectedState;
-
-	if (isUpdatingServer || !updatedServer) {
-		connectedState = server.connectedState;
-	} else if (updatedServer && updatedServer.uuid === server.uuid) {
-		connectedState = updatedServer?.connectedState;
-	}
-
-	return connectedState || ConnectedState.PENDING;
-};
-
 type ConnectionPanelTopProps = {
 	server: JenkinsServer,
 	refreshServers(serverToRemove: JenkinsServer): void,
@@ -47,14 +31,11 @@ type ConnectionPanelTopProps = {
 	isUpdatingServer: boolean
 };
 const ConnectionPanelTop = ({
-
 	server,
-	refreshServers,
-	updatedServer,
-	isUpdatingServer
+	refreshServers
 }: ConnectionPanelTopProps): JSX.Element => {
 	const history = useHistory();
-	const connectedState = setConnectedState(server, isUpdatingServer, updatedServer);
+	const connectedState = server.connectedState || ConnectedState.PENDING;
 	const { textColor, backgroundColor } = connectedStateColors[connectedState];
 	const [serverToDisconnect, setServerToDisconnect] = useState<JenkinsServer>();
 	const [showConfirmServerDisconnect, setShowConfirmServerDisconnect] = useState(false);

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelTop.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelTop.tsx
@@ -66,8 +66,9 @@ const ConnectionPanelTop = ({
 	};
 
 	const onClickConnectionSettings = async (serverToOpen: JenkinsServer) => {
-		history.push(`/setup/${serverToOpen.uuid}`);
+		history.push(`/setup/${serverToOpen.uuid}/connection-settings`);
 	};
+
 	const onClickRename = async (serverToRename: JenkinsServer) => {
 		history.push(`/update-server-name/${serverToRename.uuid}`);
 	};

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/NotConnectedState.test.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/NotConnectedState.test.tsx
@@ -22,16 +22,13 @@ describe('NotConnectedState', () => {
 
 	const refreshServers = jest.fn();
 	const handleRefreshAfterUpdate = jest.fn();
-	const setIsLoading = jest.fn();
 
 	test('renders with connected state DUPLICATE', () => {
 		render(<NotConnectedState
 			connectedState={ConnectedState.DUPLICATE}
 			jenkinsServer={mockServer}
-			isLoading={false}
 			refreshServersAfterDelete={refreshServers}
 			refreshServersAfterUpdate={handleRefreshAfterUpdate}
-			setIsLoading={setIsLoading}
 		/>);
 		expect(screen.getByText('Duplicate server')).toBeInTheDocument();
 		expect(screen.getByText('Delete')).toBeInTheDocument();
@@ -43,8 +40,6 @@ describe('NotConnectedState', () => {
 			jenkinsServer={mockServer}
 			refreshServersAfterDelete={refreshServers}
 			refreshServersAfterUpdate={handleRefreshAfterUpdate}
-			isLoading={false}
-			setIsLoading={setIsLoading}
 		/>);
 		expect(screen.getByText('Connection pending')).toBeInTheDocument();
 		expect(screen.getByText('Refresh')).toBeInTheDocument();
@@ -58,8 +53,6 @@ describe('NotConnectedState', () => {
 			jenkinsServer={mockServer}
 			refreshServersAfterDelete={refreshServers}
 			refreshServersAfterUpdate={handleRefreshAfterUpdate}
-			isLoading={false}
-			setIsLoading={setIsLoading}
 		/>);
 
 		fireEvent.click(screen.getByText('Delete'));

--- a/app/jenkins-for-jira-ui/src/components/JenkinsSetup/JenkinsSetup.tsx
+++ b/app/jenkins-for-jira-ui/src/components/JenkinsSetup/JenkinsSetup.tsx
@@ -183,13 +183,14 @@ const JenkinsSetup = (): JSX.Element => {
 	const secretTokenRef = useRef<HTMLDivElement>(null);
 	const secretRef = useRef<HTMLDivElement>(null);
 	const webhookUrlRef = useRef<HTMLDivElement>(null);
-	const { id: uuid } = useParams<ParamTypes>();
+	const { id: uuid, settings } = useParams<ParamTypes>();
 	const [serverName, setServerName] = useState('');
 	const [showMyJenkinsAdmin, setShowMyJenkinsAdmin] = useState(false);
 	const [showIAmTheJenkinsAdmin, setShowIAmTheJenkinsAdmin] = useState(false);
 	const [webhookUrl, setWebhookUrl] = useState('');
 	const [secret, setSecret] = useState<string>('');
 	const [siteName, setSiteName] = useState<string>('');
+	const connectionSettings = settings === 'connection-settings';
 
 	const getServer = useCallback(async () => {
 		try {
@@ -261,7 +262,11 @@ const JenkinsSetup = (): JSX.Element => {
 			pathParam = 'is-admin';
 		}
 
-		history.push(`/connection-complete/${uuid}/${pathParam}`);
+		if (connectionSettings) {
+			history.push('/');
+		} else {
+			history.push(`/connection-complete/${uuid}/${pathParam}`);
+		}
 	};
 
 	const isFetchingData = !serverName || !webhookUrl || !secret;
@@ -326,7 +331,7 @@ const JenkinsSetup = (): JSX.Element => {
 									appearance="primary"
 									onClick={(e) => handleNavigateToConnectionCompleteScreen(e)}
 								>
-									Next
+									{connectionSettings ? 'Done' : 'Next'}
 								</Button>
 							) : null}
 

--- a/app/jenkins-for-jira-ui/src/components/JenkinsSetup/JenkinsSetup.tsx
+++ b/app/jenkins-for-jira-ui/src/components/JenkinsSetup/JenkinsSetup.tsx
@@ -131,13 +131,15 @@ const MyJenkinsAdmin = ({
 
 type IAmTheJenkinsAdminProps = {
 	webhookUrlRef: RefObject<HTMLDivElement>,
-	secretRef: RefObject<HTMLDivElement>
+	secretRef: RefObject<HTMLDivElement>,
+	connectionSettings: boolean
 };
 
 const IAmTheJenkinsAdmin = ({
 	handleCopyToClipboard,
 	webhookUrlRef,
-	secretRef
+	secretRef,
+	connectionSettings
 }: CopyProps & IAmTheJenkinsAdminProps): JSX.Element => {
 	const handleFollowLink = (e: React.MouseEvent): void => {
 		e.preventDefault();
@@ -172,7 +174,7 @@ const IAmTheJenkinsAdmin = ({
 				</li>
 			</ol>
 
-			<p className={cx(jenkinsSetupContent)}>When you’re done, select Next</p>
+			<p className={cx(jenkinsSetupContent)}>When you’re done, select {connectionSettings ? 'Done' : 'Next'}</p>
 		</div>
 	);
 };
@@ -321,6 +323,7 @@ const JenkinsSetup = (): JSX.Element => {
 										handleCopyToClipboard={handleCopyToClipboard}
 										webhookUrlRef={webhookUrlRef}
 										secretRef={secretRef}
+										connectionSettings={connectionSettings}
 									/>
 								) : null}
 							</div>

--- a/app/jenkins-for-jira-ui/src/components/ServerNameForm/ServerNameForm.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ServerNameForm/ServerNameForm.tsx
@@ -143,7 +143,7 @@ const ServerNameForm = (): JSX.Element => {
 				pipelines: []
 			});
 			setIsLoading(false);
-			history.push(`/setup/${uuid}`);
+			history.push(`/setup/${uuid}/new-connection`);
 		} catch (e) {
 			console.error('Error: ', e);
 		}

--- a/app/jenkins-for-jira-ui/yarn.lock
+++ b/app/jenkins-for-jira-ui/yarn.lock
@@ -3136,6 +3136,11 @@
   resolved "https://packages.atlassian.com/api/npm/npm-remote/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/lodash@^4.14.202":
+  version "4.14.202"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@types/lodash/-/lodash-4.14.202.tgz#f09dbd2fb082d507178b2f2a5c7e74bd72ff98f8"
+  integrity sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==
+
 "@types/mime@*":
   version "3.0.1"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"


### PR DESCRIPTION
**What's in this PR?**
More fixes and tidy up after wrapping up my own testing blitz 😄 

- updated the Connection settings flow so that users click 'Done' and are then navigated back to the config screen instead of the through the rest of the server creation flow.
- updated the **Refresh** logic. Noticed it wasn't always playing nice and was resulting in some UI funkiness. Have hammered it locally with servers of all different status types and is now working as it should be
