### PR TITLE
update message to account for broken global page link

### DIFF
--- a/app/jenkins-for-jira-ui/src/components/ServerManagement/ServerManagement.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ServerManagement/ServerManagement.tsx
@@ -30,6 +30,7 @@ import {
 	AnalyticsUiEventsEnum
 } from '../../common/analytics/analytics-events';
 import { AnalyticsClient } from '../../common/analytics/analytics-client';
+import { CONFIG_PAGE } from '../../common/constants';
 
 const analyticsClient = new AnalyticsClient();
 
@@ -141,14 +142,24 @@ export const updateServerOnRefresh =
 		return updatedServer;
 	};
 
-export const getSharePageMessage = (globalPageUrl: string): string => {
-	return `Hi there,
-Jenkins for Jira is now installed and connected on ${getSiteNameFromUrl(globalPageUrl)}.
+export const getSharePageMessage = (globalPageUrl: string, moduleKey?: string): string => {
+	const versionRequirementMessage = moduleKey === CONFIG_PAGE
+		? `
+Can’t see a page when you follow this link? Ask your Jira admin to update Jenkins for Jira at:
 
-To set up what build and deployment events Jenkins sends to Jira, follow the set up guide(s) on this page:
+Apps > Manage your apps > Jenkins for Jira (Official)` : '';
+
+	return `Hi there,
+Jenkins for Jira is now installed and connected on
+
+${getSiteNameFromUrl(globalPageUrl)}.
+
+To get data flowing from Jenkins to Jira, follow the set up guide(s) on this page:
+
 ${globalPageUrl}
 
-You'll need to follow the set up guide for each server connected.`;
+You'll need to follow the guide for each server connected.
+${versionRequirementMessage}`;
 };
 
 const ServerManagement = (): JSX.Element => {
@@ -291,7 +302,7 @@ const ServerManagement = (): JSX.Element => {
 		</ButtonGroup>
 	);
 
-	const sharePageMessage = getSharePageMessage(globalPageUrl);
+	const sharePageMessage = getSharePageMessage(globalPageUrl, moduleKey);
 
 	const contentToRender =
 		contentToRenderServerManagementScreen(


### PR DESCRIPTION
**What's in this PR?**
Content update to the share button copy content.

**Why**
When we changed the scope (permissions) to fix the issues with the Node runtime (forced update by Forge), a major version bump kicked in. This means Jira admins need to manually click the Update button on their manage apps page to accept the new version. Unfortunately, this overlaps with the release of our global page which will only become available once customers are on version 14 or higher. This is an issue as when we begin rolling out the J4J FF, anyone that shares the copy content from the Share page button will be sharing a link to a page that doesn't exist... and currently about 90% of our customers are on an outdated version. 

There is no way for us to make a request from a Forge app to get the version number so, to try to rectify this, we have updated the copy to prompt Jira admins to update the app should they land on a non-existent page.

Server management share page button content

<img width="570" alt="Screenshot 2024-01-29 at 1 25 57 pm" src="https://github.com/atlassian/jenkins-for-jira/assets/37155488/bfaf49f6-3222-4c79-b899-3e17e0422c84">

We're not including this on the global page share button coz then it's obviously not needed!
<img width="568" alt="Screenshot 2024-01-29 at 1 26 02 pm" src="https://github.com/atlassian/jenkins-for-jira/assets/37155488/aec4006b-62e5-4aad-b4f7-0c90fa343037">


