### PR TITLE
ARC-2807 - add admin check to global page part 1

### DIFF
--- a/app/jenkins-for-jira-ui/src/api/fetchGlobalPageUrl.ts
+++ b/app/jenkins-for-jira-ui/src/api/fetchGlobalPageUrl.ts
@@ -23,7 +23,15 @@ const fetchGlobalPageUrl = async (): Promise<string> => {
 	return `${siteUrl}/jira/apps/${appId}/${environmentId}`;
 };
 
+const fetchAdminPath = async (): Promise<string> => {
+	const context: FetchGlobalPageUrlContext = await invoke('fetchAppData');
+	const { appId, environmentId } = context;
+
+	return `/jira/settings/apps/${appId}/${environmentId}`;
+};
+
 export {
 	fetchGlobalPageUrl,
-	fetchSiteName
+	fetchSiteName,
+	fetchAdminPath
 };

--- a/app/jenkins-for-jira-ui/src/api/fetchUserPerms.ts
+++ b/app/jenkins-for-jira-ui/src/api/fetchUserPerms.ts
@@ -1,0 +1,10 @@
+import { invoke } from '@forge/bridge';
+
+const fetchUserPerms = async (): Promise<boolean> => {
+	const userIsAdmin: boolean = await invoke('fetchUserPerms');
+	return userIsAdmin;
+};
+
+export {
+	fetchUserPerms
+};

--- a/app/src/resolvers.ts
+++ b/app/src/resolvers.ts
@@ -16,7 +16,7 @@ import { FetchAppDataProps, fetchAppData } from './utils/fetch-app-data';
 import { fetchFeatureFlag } from './config/feature-flags';
 import { fetchModuleKey } from './utils/fetch-module-key';
 import { GLOBAL_PAGE } from '../jenkins-for-jira-ui/src/common/constants';
-import { fetchUserPerms } from './storage/fetch-user-perms';
+import { fetchUserPerms } from './utils/fetch-user-perms';
 
 const resolver = new Resolver();
 

--- a/app/src/resolvers.ts
+++ b/app/src/resolvers.ts
@@ -16,6 +16,7 @@ import { FetchAppDataProps, fetchAppData } from './utils/fetch-app-data';
 import { fetchFeatureFlag } from './config/feature-flags';
 import { fetchModuleKey } from './utils/fetch-module-key';
 import { GLOBAL_PAGE } from '../jenkins-for-jira-ui/src/common/constants';
+import { fetchUserPerms } from './storage/fetch-user-perms';
 
 const resolver = new Resolver();
 
@@ -104,6 +105,10 @@ resolver.define('fetchAppData', async (req): Promise<FetchAppDataProps> => {
 
 resolver.define('fetchModuleKey', async (req): Promise<string> => {
 	return fetchModuleKey(req);
+});
+
+resolver.define('fetchUserPerms', async (req): Promise<boolean> => {
+	return fetchUserPerms(req);
 });
 
 export default resolver.getDefinitions();

--- a/app/src/storage/fetch-user-perms.ts
+++ b/app/src/storage/fetch-user-perms.ts
@@ -4,7 +4,6 @@ import { Logger } from '../config/logger';
 const fetchUserPerms = async (req: any): Promise<boolean> => {
     const logger = Logger.getInstance('blah');
     const { accountId } = req.context;
-    logger.info('accountId', { accountId });
 
     const permissionRequestBody = `{
 		"globalPermissions": [

--- a/app/src/storage/fetch-user-perms.ts
+++ b/app/src/storage/fetch-user-perms.ts
@@ -1,0 +1,29 @@
+import api, { route } from '@forge/api';
+import { Logger } from '../config/logger';
+
+const fetchUserPerms = async (req: any): Promise<boolean> => {
+    const logger = Logger.getInstance('blah');
+    const { accountId } = req.context;
+    logger.info('accountId', { accountId });
+
+    const permissionRequestBody = `{
+		"globalPermissions": [
+			"ADMINISTER"
+		],
+		"accountId": "${accountId}"
+	}`;
+
+    const permissions = await api.asUser().requestJira(route`/rest/api/3/permissions/check`, {
+        method: 'POST',
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json'
+        },
+        body: permissionRequestBody
+    });
+
+    const permissionDetails = await permissions.json();
+    return !!permissionDetails?.globalPermissions?.includes('ADMINISTER');
+};
+
+export { fetchUserPerms };

--- a/app/src/utils/fetch-user-perms.ts
+++ b/app/src/utils/fetch-user-perms.ts
@@ -1,8 +1,6 @@
 import api, { route } from '@forge/api';
-import { Logger } from '../config/logger';
 
 const fetchUserPerms = async (req: any): Promise<boolean> => {
-    const logger = Logger.getInstance('blah');
     const { accountId } = req.context;
 
     const permissionRequestBody = `{


### PR DESCRIPTION
**What's in this PR?**
Update to the backend and addition of API on the frontend

**Why**
Currently, we're hiding action buttons from all users on the global page but we want admins to see them regardless of whether they are on the admin/global page. To do this, we need to make a request to the backend to get the users permission level. 

This is part 1 - originally had it altogether but the size was getting a little wiley.

**Added feature flags**
check_user_permissions

**Affected issues**  
ARC-2807

**How has this been tested?**  
Locally and in staging. Needs to go to prod before I can make sure the buttons still aren't visible in the non-admin account coz they don't have access to dev/stg instances. Thank god for feature flags hey? :blobeyebrows:

**What's Next?**
Get this merged and then open a PR with the rest of the changes.