### PR TITLE
NONE update analytics

### DIFF
--- a/app/jenkins-for-jira-ui/src/common/analytics/analytics-events.ts
+++ b/app/jenkins-for-jira-ui/src/common/analytics/analytics-events.ts
@@ -55,7 +55,8 @@ export enum AnalyticsUiEventsEnum {
 	ConnectionSettingsName = 'connectionSettings',
 	DisconnectServerName = 'disconnectServer',
 	ConfirmDisconnectServerName = 'confirmDisconnectServer',
-	SetUpGuideName = 'setUpGuide'
+	SetUpGuideName = 'setUpGuide',
+	ConnectANewJenkinsServerName = 'ConnectANewJenkinsServer'
 }
 
 export enum AnalyticsTrackEventsEnum {

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelTop.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelTop.tsx
@@ -18,7 +18,7 @@ import { JenkinsModal } from '../JenkinsServerList/ConnectedServer/JenkinsModal'
 import { JenkinsServer } from '../../../../src/common/types';
 import { CONFIG_PAGE, DISCONNECT_MODAL_TEST_ID } from '../../common/constants';
 import {
-	AnalyticsEventTypes,
+	AnalyticsEventTypes, AnalyticsScreenEventsEnum,
 	AnalyticsTrackEventsEnum,
 	AnalyticsUiEventsEnum
 } from '../../common/analytics/analytics-events';
@@ -58,6 +58,8 @@ const ConnectionPanelTop = ({
 	const [disconnectError, setDisconnectError] = useState<boolean>(false);
 	const [adminPageUrl, setAdminPageUrl] = useState<string>('');
 	const isAdminPage = moduleKey === CONFIG_PAGE;
+	const pageSource = isAdminPage
+		? AnalyticsScreenEventsEnum.ServerManagementScreenName : AnalyticsScreenEventsEnum.GlobalPageScreenName;
 
 	useEffect(() => {
 		const fetchData = async () => {
@@ -80,6 +82,7 @@ const ConnectionPanelTop = ({
 			AnalyticsEventTypes.UiEvent,
 			AnalyticsUiEventsEnum.DisconnectServerName,
 			{
+				source: pageSource,
 				action: `clicked - ${AnalyticsUiEventsEnum.DisconnectServerName}`,
 				actionSubject: 'button'
 			}
@@ -91,6 +94,7 @@ const ConnectionPanelTop = ({
 			AnalyticsEventTypes.UiEvent,
 			AnalyticsUiEventsEnum.ConnectionSettingsName,
 			{
+				source: pageSource,
 				action: `clicked - ${AnalyticsUiEventsEnum.ConnectionSettingsName}`,
 				actionSubject: 'button'
 			}
@@ -110,6 +114,7 @@ const ConnectionPanelTop = ({
 			AnalyticsEventTypes.UiEvent,
 			AnalyticsUiEventsEnum.RenameServerName,
 			{
+				source: pageSource,
 				action: `clicked - ${AnalyticsUiEventsEnum.RenameServerName}`,
 				actionSubject: 'button'
 			}

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelTop.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelTop.tsx
@@ -18,7 +18,8 @@ import { JenkinsModal } from '../JenkinsServerList/ConnectedServer/JenkinsModal'
 import { JenkinsServer } from '../../../../src/common/types';
 import { CONFIG_PAGE, DISCONNECT_MODAL_TEST_ID } from '../../common/constants';
 import {
-	AnalyticsEventTypes, AnalyticsScreenEventsEnum,
+	AnalyticsEventTypes,
+	AnalyticsScreenEventsEnum,
 	AnalyticsTrackEventsEnum,
 	AnalyticsUiEventsEnum
 } from '../../common/analytics/analytics-events';

--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/NotConnectedState.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/NotConnectedState.tsx
@@ -11,7 +11,11 @@ import { disconnectJenkinsServer } from '../../api/disconnectJenkinsServer';
 import { ConnectionPanelContent } from './ConnectionPanelContent';
 import { CONFIG_PAGE, DELETE_MODAL_TEST_ID } from '../../common/constants';
 import { JenkinsModal } from '../JenkinsServerList/ConnectedServer/JenkinsModal';
-import { AnalyticsEventTypes, AnalyticsTrackEventsEnum } from '../../common/analytics/analytics-events';
+import {
+	AnalyticsEventTypes,
+	AnalyticsScreenEventsEnum,
+	AnalyticsTrackEventsEnum
+} from '../../common/analytics/analytics-events';
 import { AnalyticsClient } from '../../common/analytics/analytics-client';
 
 const analyticsClient = new AnalyticsClient();
@@ -40,6 +44,8 @@ const NotConnectedState = ({
 	const [serverToDeleteUuid, setServerToDeleteUuid] = useState<string>('');
 	const [isDeletingServer, setIsDeletingServer] = useState<boolean>(false);
 	const [showRetryServerDelete, setShowRetryServerDelete] = useState<boolean>(false);
+	const pageSource = moduleKey === CONFIG_PAGE
+		? AnalyticsScreenEventsEnum.ServerManagementScreenName : AnalyticsScreenEventsEnum.GlobalPageScreenName;
 
 	const deleteServer = async (serverToDelete: JenkinsServer) => {
 		setIsDeletingServer(true);
@@ -52,6 +58,7 @@ const NotConnectedState = ({
 				AnalyticsEventTypes.TrackEvent,
 				AnalyticsTrackEventsEnum.DeleteServerSuccessName,
 				{
+					source: pageSource,
 					action: `submitted ${AnalyticsTrackEventsEnum.DeleteServerSuccessName}`,
 					actionSubject: 'form'
 				}
@@ -65,6 +72,7 @@ const NotConnectedState = ({
 				AnalyticsEventTypes.TrackEvent,
 				AnalyticsTrackEventsEnum.DeleteServerFailureName,
 				{
+					source: pageSource,
 					action: `submitted ${AnalyticsTrackEventsEnum.DeleteServerFailureName}`,
 					actionSubject: 'form'
 				}

--- a/app/jenkins-for-jira-ui/src/components/GlobalPage/GlobalPage.tsx
+++ b/app/jenkins-for-jira-ui/src/components/GlobalPage/GlobalPage.tsx
@@ -164,6 +164,17 @@ export const GlobalPage = ({ checkUserPermissionsFlag }: GlobalPageProps): JSX.E
 	const handleNavigateToServerNameScreen = async (e: React.MouseEvent) => {
 		e.preventDefault();
 		const adminPath = await fetchAdminPath();
+
+		await analyticsClient.sendAnalytics(
+			AnalyticsEventTypes.UiEvent,
+			AnalyticsUiEventsEnum.ConnectANewJenkinsServerName,
+			{
+				source: AnalyticsScreenEventsEnum.GlobalPageScreenName,
+				action: `clicked - ${AnalyticsUiEventsEnum.ConnectANewJenkinsServerName}`,
+				actionSubject: 'button'
+			}
+		);
+
 		router.navigate(`${adminPath}/connection-info/global`);
 	};
 

--- a/app/jenkins-for-jira-ui/src/components/ServerManagement/ServerManagement.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ServerManagement/ServerManagement.tsx
@@ -261,8 +261,19 @@ const ServerManagement = (): JSX.Element => {
 		};
 	}, [redirectToAdminPage]);
 
-	const handleNavigateToServerNameScreen = (e: React.MouseEvent) => {
+	const handleNavigateToServerNameScreen = async (e: React.MouseEvent) => {
 		e.preventDefault();
+
+		await analyticsClient.sendAnalytics(
+			AnalyticsEventTypes.UiEvent,
+			AnalyticsUiEventsEnum.ConnectANewJenkinsServerName,
+			{
+				source: AnalyticsScreenEventsEnum.ServerManagementScreenName,
+				action: `clicked - ${AnalyticsUiEventsEnum.ConnectANewJenkinsServerName}`,
+				actionSubject: 'button'
+			}
+		);
+
 		history.push('/connection-info/admin');
 	};
 


### PR DESCRIPTION
**What's in this PR?**
Added source (page where event was fired) to a few analytics + 1 new analytic

**Why**
Previously certain actions could only be fired on the admin page but, now that we're exposing the buttons for admins on the global page, we need to know where the event is coming from.

**Added feature flags**
nah

**Affected issues**  
NONE

**What's Next?**
Update the analytic events and register a new one.