### PR TITLE
global & server management page reuse share page component

### DIFF
--- a/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelMain.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ConnectionPanel/ConnectionPanelMain.tsx
@@ -95,6 +95,7 @@ const ConnectionPanelMain = ({
 
 	const handleClickSetupGuide = () => {
 		setSelectedTabIndex(SET_UP_GUIDE_TAB);
+		setShowSharePageContainer(true);
 	};
 
 	const pageSource =
@@ -261,7 +262,7 @@ const ConnectionPanelMain = ({
 						</div>
 						<div className={cx(setupGuideButtonContainer)}>
 							<SharePage
-								analyticsUIScreenNameEnum={AnalyticsUiEventsEnum.SetUpGuideName}
+								analyticsScreenEventNameEnum={AnalyticsScreenEventsEnum.JenkinsSetupScreenName}
 								buttonAppearance='primary'/>
 							<Button>
 								<InProductHelpAction

--- a/app/jenkins-for-jira-ui/src/components/GlobalPage/GlobalPage.tsx
+++ b/app/jenkins-for-jira-ui/src/components/GlobalPage/GlobalPage.tsx
@@ -136,8 +136,7 @@ export const GlobalPage = ({ checkUserPermissionsFlag }: GlobalPageProps): JSX.E
 				</Button>
 			}
 			<SharePage
-				analyticsScreenEventNameEnum={AnalyticsScreenEventsEnum.GlobalPageScreenName}
-				buttonAppearance='primary'/>
+				analyticsScreenEventNameEnum={AnalyticsScreenEventsEnum.GlobalPageScreenName}/>
 		</ButtonGroup>
 	);
 

--- a/app/jenkins-for-jira-ui/src/components/GlobalPage/GlobalPage.tsx
+++ b/app/jenkins-for-jira-ui/src/components/GlobalPage/GlobalPage.tsx
@@ -1,8 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PageHeader from '@atlaskit/page-header';
 import Button from '@atlaskit/button/standard-button';
-import { cx } from '@emotion/css';
-import TextArea from '@atlaskit/textarea';
 import { isEqual } from 'lodash';
 import { ButtonGroup } from '@atlaskit/button';
 import { router } from '@forge/bridge';
@@ -13,20 +11,19 @@ import { JenkinsServer } from '../../../../src/common/types';
 import { addConnectedState, ConnectionPanel } from '../ConnectionPanel/ConnectionPanel';
 import { headerContainer } from '../JenkinsServerList/JenkinsServerList.styles';
 import { TopPanel } from '../ServerManagement/TopPanel/TopPanel';
-import { getSharePageMessage, updateServerOnRefresh } from '../ServerManagement/ServerManagement';
+import { updateServerOnRefresh } from '../ServerManagement/ServerManagement';
 import {
 	AnalyticsEventTypes,
 	AnalyticsScreenEventsEnum,
 	AnalyticsUiEventsEnum
 } from '../../common/analytics/analytics-events';
 import { AnalyticsClient } from '../../common/analytics/analytics-client';
-import { JenkinsModal } from '../JenkinsServerList/ConnectedServer/JenkinsModal';
-import { shareModalInstruction } from '../ServerManagement/ServerManagement.styles';
-import { fetchAdminPath, fetchGlobalPageUrl } from '../../api/fetchGlobalPageUrl';
+import { fetchAdminPath } from '../../api/fetchGlobalPageUrl';
 import { fetchModuleKey } from '../../api/fetchModuleKey';
 import { GlobalPageEmptyState } from './GlobalPageEmptyState';
 import { getJenkinsServerWithSecret } from '../../api/getJenkinsServerWithSecret';
 import { fetchUserPerms } from '../../api/fetchUserPerms';
+import { SharePage } from '../SharePage/SharePage';
 
 const analyticsClient = new AnalyticsClient();
 
@@ -36,11 +33,7 @@ type GlobalPageProps = {
 
 export const GlobalPage = ({ checkUserPermissionsFlag }: GlobalPageProps): JSX.Element => {
 	const [jenkinsServers, setJenkinsServers] = useState<JenkinsServer[]>();
-	const [showSharePage, setShowSharePage] = useState<boolean>(false);
-	const textAreaRef = useRef<HTMLTextAreaElement>(null);
 	const isMountedRef = React.useRef<boolean>(true);
-	const [isCopiedToClipboard, setIsCopiedToClipboard] = useState(false);
-	const [globalPageUrl, setGlobalPageUrl] = useState<string>('');
 	const [moduleKey, setModuleKey] = useState<string>();
 	const [updatedServer, setUpdatedServer] = useState<JenkinsServer>();
 	const [isUpdatingServer, setIsUpdatingServer] = useState<boolean>(false);
@@ -62,8 +55,6 @@ export const GlobalPage = ({ checkUserPermissionsFlag }: GlobalPageProps): JSX.E
 	useEffect(() => {
 		const fetchData = async () => {
 			try {
-				const url = await fetchGlobalPageUrl();
-				setGlobalPageUrl(url);
 				await fetchAllJenkinsServers();
 				await getModuleKey();
 
@@ -88,50 +79,6 @@ export const GlobalPage = ({ checkUserPermissionsFlag }: GlobalPageProps): JSX.E
 	if (!jenkinsServers || !moduleKey || isFetchingAdminPerms) {
 		return <JenkinsSpinner secondaryClassName={spinnerHeight} />;
 	}
-
-	const handleShowSharePageModal = async () => {
-		await analyticsClient.sendAnalytics(
-			AnalyticsEventTypes.UiEvent,
-			AnalyticsUiEventsEnum.SharePageName,
-			{
-				source: AnalyticsScreenEventsEnum.GlobalPageScreenName,
-				action: `clicked - ${AnalyticsUiEventsEnum.SharePageName}`,
-				actionSubject: 'button'
-			}
-		);
-
-		setShowSharePage(true);
-	};
-
-	const handleCopyToClipboard = async () => {
-		await analyticsClient.sendAnalytics(
-			AnalyticsEventTypes.UiEvent,
-			AnalyticsUiEventsEnum.CopiedToClipboardName,
-			{
-				source: AnalyticsScreenEventsEnum.GlobalPageScreenName,
-				action: `clicked - ${AnalyticsUiEventsEnum.CopiedToClipboardName}`,
-				actionSubject: 'button'
-			}
-		);
-
-		if (textAreaRef.current) {
-			textAreaRef.current.select();
-			document.execCommand('copy');
-			textAreaRef.current.setSelectionRange(textAreaRef.current.value.length, textAreaRef.current.value.length);
-
-			setIsCopiedToClipboard(true);
-
-			setTimeout(() => {
-				if (isMountedRef.current) {
-					setIsCopiedToClipboard(false);
-				}
-			}, 2000);
-		}
-	};
-
-	const handleCloseShowSharePageModal = async () => {
-		setShowSharePage(false);
-	};
 
 	const handleRefreshUpdateServer = async (uuid: string) => {
 		setIsUpdatingServer(true);
@@ -188,11 +135,11 @@ export const GlobalPage = ({ checkUserPermissionsFlag }: GlobalPageProps): JSX.E
 					Connect a new Jenkins server
 				</Button>
 			}
-			<Button onClick={() => handleShowSharePageModal()}>Share page</Button>
+			<SharePage
+				analyticsScreenEventNameEnum={AnalyticsScreenEventsEnum.GlobalPageScreenName}
+				buttonAppearance='primary'/>
 		</ButtonGroup>
 	);
-
-	const sharePageMessage = getSharePageMessage(globalPageUrl);
 
 	return (
 		<div>
@@ -218,33 +165,6 @@ export const GlobalPage = ({ checkUserPermissionsFlag }: GlobalPageProps): JSX.E
 					<TopPanel />
 					<GlobalPageEmptyState />
 				</>
-			}
-
-			{
-				showSharePage && <JenkinsModal
-					dataTestId="share-page-modal"
-					title="Share page"
-					body={[
-						<p key="share-message" className={cx(shareModalInstruction)}>
-							Share this link with your project teams to help them set up what
-							data they receive from Jenkins.
-						</p>,
-						<TextArea
-							key="text-area"
-							ref={textAreaRef}
-							value={sharePageMessage}
-							isReadOnly
-							minimumRows={5}
-						/>
-					]}
-					onClose={handleCloseShowSharePageModal}
-					primaryButtonAppearance="subtle"
-					primaryButtonLabel="Close"
-					secondaryButtonAppearance="primary"
-					secondaryButtonLabel="Copy to clipboard"
-					secondaryButtonOnClick={handleCopyToClipboard}
-					isCopiedToClipboard={isCopiedToClipboard}
-				/>
 			}
 		</div>
 	);

--- a/app/jenkins-for-jira-ui/src/components/ServerManagement/ServerManagement.test.tsx
+++ b/app/jenkins-for-jira-ui/src/components/ServerManagement/ServerManagement.test.tsx
@@ -173,18 +173,6 @@ describe('ServerManagement Component', () => {
 		expect(screen.getByTestId('connection-wizard')).toBeInTheDocument();
 	});
 
-	test('should copy to clipboard when "Copy to clipboard" is clicked', async () => {
-		jest.spyOn(getAllJenkinsServersModule, 'getAllJenkinsServers').mockResolvedValueOnce([servers[4]]);
-		jest.spyOn(redirectFromGetStartedModule, 'redirectFromGetStarted').mockResolvedValueOnce(CONFIG_PAGE);
-		jest.spyOn(fetchGlobalPageUrlModule, 'fetchGlobalPageUrl').mockResolvedValueOnce('https://somesite.atlassian.net/blah');
-
-		await waitFor(() => render(<ServerManagement />));
-		await waitFor(() => fireEvent.click(screen.getByText('Share page')));
-		await waitFor(() => fireEvent.click(screen.getByText('Copy to clipboard')));
-		await waitFor(() => screen.getByText('Copied to clipboard'));
-		expect(document.execCommand).toHaveBeenCalledWith('copy');
-	});
-
 	test('should close the share modal when "Close" is clicked', async () => {
 		jest.spyOn(getAllJenkinsServersModule, 'getAllJenkinsServers').mockResolvedValueOnce(servers);
 		jest.spyOn(redirectFromGetStartedModule, 'redirectFromGetStarted').mockResolvedValueOnce(CONFIG_PAGE);

--- a/app/jenkins-for-jira-ui/src/components/SharePage/SharePage.test.tsx
+++ b/app/jenkins-for-jira-ui/src/components/SharePage/SharePage.test.tsx
@@ -4,7 +4,7 @@ import {
 import { EventType, JenkinsServer } from '../../../../src/common/types';
 import * as getAllJenkinsServersModule from '../../api/getAllJenkinsServers';
 import * as fetchGlobalPageUrlModule from '../../api/fetchGlobalPageUrl';
-import { AnalyticsUiEventsEnum } from '../../common/analytics/analytics-events';
+import { AnalyticsScreenEventsEnum } from '../../common/analytics/analytics-events';
 import { SharePage } from './SharePage';
 
 const testJenkinsServer: JenkinsServer = {
@@ -38,7 +38,7 @@ describe('SharePage Component', () => {
 		jest.spyOn(getAllJenkinsServersModule, 'getAllJenkinsServers').mockResolvedValueOnce([testJenkinsServer]);
 		jest.spyOn(fetchGlobalPageUrlModule, 'fetchGlobalPageUrl').mockResolvedValueOnce('https://somesite.atlassian.net/blah');
 
-		await waitFor(() => render(<SharePage analyticsUIScreenNameEnum={AnalyticsUiEventsEnum.SetUpGuideName}/>));
+		await waitFor(() => render(<SharePage analyticsScreenEventNameEnum={AnalyticsScreenEventsEnum.JenkinsSetupScreenName}/>));
 		await waitFor(() => fireEvent.click(screen.getByText('Share page')));
 		await waitFor(() => fireEvent.click(screen.getByText('Copy to clipboard')));
 		await waitFor(() => screen.getByText('Copied to clipboard'));
@@ -49,7 +49,7 @@ describe('SharePage Component', () => {
 		jest.spyOn(getAllJenkinsServersModule, 'getAllJenkinsServers').mockResolvedValueOnce([testJenkinsServer]);
 		jest.spyOn(fetchGlobalPageUrlModule, 'fetchGlobalPageUrl').mockResolvedValueOnce('https://somesite.atlassian.net/blah');
 
-		await waitFor(() => render(<SharePage analyticsUIScreenNameEnum={AnalyticsUiEventsEnum.SetUpGuideName}/>));
+		await waitFor(() => render(<SharePage analyticsScreenEventNameEnum={AnalyticsScreenEventsEnum.JenkinsSetupScreenName}/>));
 		await waitFor(() => fireEvent.click(screen.getByText('Share page')));
 
 		expect(screen.getByText('Copy to clipboard')).toBeInTheDocument();

--- a/app/jenkins-for-jira-ui/src/components/SharePage/SharePage.tsx
+++ b/app/jenkins-for-jira-ui/src/components/SharePage/SharePage.tsx
@@ -8,7 +8,7 @@ import React, {
 import Button from '@atlaskit/button';
 import TextArea from '@atlaskit/textarea';
 import { cx } from '@emotion/css';
-import { AnalyticsEventTypes, AnalyticsUiEventsEnum } from '../../common/analytics/analytics-events';
+import { AnalyticsEventTypes, AnalyticsScreenEventsEnum, AnalyticsUiEventsEnum } from '../../common/analytics/analytics-events';
 import { AnalyticsClient } from '../../common/analytics/analytics-client';
 import { JenkinsModal } from '../JenkinsServerList/ConnectedServer/JenkinsModal';
 import { shareModalInstruction } from '../ServerManagement/ServerManagement.styles';
@@ -28,7 +28,7 @@ export const getSiteNameFromUrl = (url: string): string => {
 	}
 };
 
-export const getSharePageMessage = (globalPageUrl: string, moduleKey?: string): string => {
+const getSharePageMessage = (globalPageUrl: string, moduleKey?: string): string => {
 	const versionRequirementMessage = moduleKey === CONFIG_PAGE
 		? `
 Can’t see a page when you follow this link? Ask your Jira admin to update Jenkins for Jira at:
@@ -49,13 +49,15 @@ ${versionRequirementMessage}`;
 };
 
 type SharePageProps = {
-	analyticsUIScreenNameEnum: AnalyticsUiEventsEnum;
+	analyticsScreenEventNameEnum: AnalyticsScreenEventsEnum;
 	buttonAppearance?: string;
+	moduleKey?: string;
 };
 
 export const SharePage = ({
-	analyticsUIScreenNameEnum,
-	buttonAppearance
+	analyticsScreenEventNameEnum,
+	buttonAppearance,
+	moduleKey
 }:SharePageProps): JSX.Element => {
 	const textAreaRef = useRef<HTMLTextAreaElement>(null);
 	const [isCopiedToClipboard, setIsCopiedToClipboard] = useState(false);
@@ -76,8 +78,8 @@ export const SharePage = ({
 		};
 
 		await fetchData();
-		setSharePageMessage(getSharePageMessage(globalPageUrl));
-	}, [globalPageUrl]);
+		setSharePageMessage(getSharePageMessage(globalPageUrl, moduleKey));
+	}, [globalPageUrl, moduleKey]);
 
 	useEffect(() => {
 		constructSharePageMessage();
@@ -92,7 +94,7 @@ export const SharePage = ({
 			AnalyticsEventTypes.UiEvent,
 			AnalyticsUiEventsEnum.SharePageName,
 			{
-				source: analyticsUIScreenNameEnum,
+				source: analyticsScreenEventNameEnum,
 				action: `clicked - ${AnalyticsUiEventsEnum.SharePageName}`,
 				actionSubject: 'button'
 			}
@@ -110,7 +112,7 @@ export const SharePage = ({
 			AnalyticsEventTypes.UiEvent,
 			AnalyticsUiEventsEnum.CopiedToClipboardName,
 			{
-				source: analyticsUIScreenNameEnum,
+				source: analyticsScreenEventNameEnum,
 				action: `clicked - ${AnalyticsUiEventsEnum.CopiedToClipboardName}`,
 				actionSubject: 'button'
 			}


### PR DESCRIPTION
**What's in this PR?**

Refactoring code to reuse share page component so that it is easier to mange and update component in future. A base step for Jenkins Phase 1.1 Design Improvement task 1.2

**Affected issues**  

ARC-2911

**How has this been tested?**  
yarn test &
Manual UI testing
In global page
<img width="976" alt="Screenshot 2024-02-26 at 11 58 26 am" src="https://github.com/atlassian/jenkins-for-jira/assets/156405106/503bad3c-5d8c-46fe-9e8f-fe94138a0a56">

In server management page,

<img width="982" alt="Screenshot 2024-02-26 at 11 54 52 am" src="https://github.com/atlassian/jenkins-for-jira/assets/156405106/b08dda8e-f2ad-443f-9140-56a2449e509a">



**What's Next?**

Continue on design 1.2 task, which is updating the share page text content.