### PR TITLE
ARC-3241 Clean BulkByProperties api call to remove cloud id as this is redundant

### DIFF
--- a/app/src/jira-client/delete-builds.ts
+++ b/app/src/jira-client/delete-builds.ts
@@ -15,7 +15,7 @@ async function deleteBuilds(cloudId: string, jenkinsServerUuid?: string): Promis
 	let deleteBuildsRoute: Route;
 	if (jenkinsServerUuid) {
 		// eslint-disable-next-line max-len
-		deleteBuildsRoute = route`/builds/0.1/cloud/${cloudId}/bulkByProperties?cloudId=${cloudId}&jenkinsServerUuid=${jenkinsServerUuid}`;
+		deleteBuildsRoute = route`/builds/0.1/cloud/${cloudId}/bulkByProperties?jenkinsServerUuid=${jenkinsServerUuid}`;
 	} else {
 		deleteBuildsRoute = route`/builds/0.1/cloud/${cloudId}/bulkByProperties?cloudId=${cloudId}`;
 	}


### PR DESCRIPTION
**What's in this PR?**
Remove redundant cloudId property for DD endpoint

**Why**
DD want to restrict endpoint to one property

**Affected issues**  
ARC-3241

**Testing**
Tested by deploying to staging and testing disconnection. See Jira ticket for loom.
