### PR TITLE
Replace `requestConnectedData` with `requestJira`

### DIFF
--- a/app/src/jira-client/delete-builds.test.ts
+++ b/app/src/jira-client/delete-builds.test.ts
@@ -6,7 +6,7 @@ import { InvalidPayloadError } from '../common/error';
 jest.mock('@forge/api', () => ({
 	...jest.requireActual('@forge/api'),
 	asApp: jest.fn().mockReturnValue({
-		requestConnectedData: jest.fn()
+		requestJira: jest.fn()
 	})
 }));
 
@@ -18,7 +18,7 @@ describe('deleteBuilds suite', () => {
 
 	it('Should return status for successful response', async () => {
 		const mockResponse = { status: 200 };
-		api.asApp().requestConnectedData = jest.fn().mockImplementation(() => ({
+		api.asApp().requestJira = jest.fn().mockImplementation(() => ({
 			then: (callback: any) => Promise.resolve(callback(mockResponse))
 		}));
 

--- a/app/src/jira-client/delete-builds.ts
+++ b/app/src/jira-client/delete-builds.ts
@@ -15,14 +15,14 @@ async function deleteBuilds(cloudId: string, jenkinsServerUuid?: string): Promis
 	let deleteBuildsRoute: Route;
 	if (jenkinsServerUuid) {
 		// eslint-disable-next-line max-len
-		deleteBuildsRoute = route`/builds/0.1/cloud/${cloudId}/bulkByProperties?jenkinsServerUuid=${jenkinsServerUuid}`;
+		deleteBuildsRoute = route`/rest/builds/0.1/bulkByProperties?jenkinsServerUuid=${jenkinsServerUuid}`;
 	} else {
-		deleteBuildsRoute = route`/builds/0.1/cloud/${cloudId}/bulkByProperties?cloudId=${cloudId}`;
+		deleteBuildsRoute = route`/rest/builds/0.1/bulkByProperties?cloudId=${cloudId}`;
 	}
 
 	const apiResponse = await api
 		.asApp()
-		.requestConnectedData(deleteBuildsRoute, {
+		.requestJira(deleteBuildsRoute, {
 			method: 'DELETE'
 		});
 

--- a/app/src/jira-client/delete-deployments.test.ts
+++ b/app/src/jira-client/delete-deployments.test.ts
@@ -6,7 +6,7 @@ import { InvalidPayloadError } from '../common/error';
 jest.mock('@forge/api', () => ({
 	...jest.requireActual('@forge/api'),
 	asApp: jest.fn().mockReturnValue({
-		requestConnectedData: jest.fn()
+		requestJira: jest.fn()
 	})
 }));
 
@@ -18,7 +18,7 @@ describe('deleteDeployments suite', () => {
 
 	it('Should return status for successful response', async () => {
 		const mockResponse = { status: 200 };
-		api.asApp().requestConnectedData = jest.fn().mockImplementation(() => ({
+		api.asApp().requestJira = jest.fn().mockImplementation(() => ({
 			then: (callback: any) => Promise.resolve(callback(mockResponse))
 		}));
 

--- a/app/src/jira-client/delete-deployments.ts
+++ b/app/src/jira-client/delete-deployments.ts
@@ -15,16 +15,16 @@ async function deleteDeployments(cloudId: string, jenkinsServerUuid?: string): P
 	let deleteDeploymentsRoute: Route;
 	if (jenkinsServerUuid) {
 		// eslint-disable-next-line max-len
-		deleteDeploymentsRoute = route`/deployments/0.1/cloud/${cloudId}/bulkByProperties?cloudId=${cloudId}&jenkinsServerUuid=${jenkinsServerUuid}`;
+		deleteDeploymentsRoute = route`/rest/deployments/0.1/bulkByProperties?cloudId=${cloudId}&jenkinsServerUuid=${jenkinsServerUuid}`;
 	} else {
-		deleteDeploymentsRoute = route`/deployments/0.1/cloud/${cloudId}/bulkByProperties?cloudId=${cloudId}`;
+		deleteDeploymentsRoute = route`/rest/deployments/0.1/bulkByProperties?cloudId=${cloudId}`;
 	}
 
 	// @ts-ignore // required so that Typescript doesn't complain about the missing "api" property
 	// eslint-disable-next-line no-underscore-dangle
 	const apiResponse = await api
 		.asApp()
-		.requestConnectedData(deleteDeploymentsRoute, {
+		.requestJira(deleteDeploymentsRoute, {
 			method: 'DELETE'
 		});
 

--- a/app/src/jira-client/get-gating-status-from-jira.test.ts
+++ b/app/src/jira-client/get-gating-status-from-jira.test.ts
@@ -6,7 +6,7 @@ import { InvalidPayloadError } from '../common/error';
 jest.mock('@forge/api', () => ({
 	...jest.requireActual('@forge/api'),
 	asApp: jest.fn().mockReturnValue({
-		requestConnectedData: jest.fn()
+		requestJira: jest.fn()
 	})
 }));
 
@@ -33,7 +33,7 @@ describe('getGatingStatusFromJira suite', () => {
 
 	it('Should return status with empty body if no responseString is returned', async () => {
 		const mockResponse = { status: 200, text: jest.fn() };
-		api.asApp().requestConnectedData = jest.fn().mockImplementation(() => ({
+		api.asApp().requestJira = jest.fn().mockImplementation(() => ({
 			then: (callback: any) => Promise.resolve(callback(mockResponse))
 		}));
 
@@ -60,7 +60,7 @@ describe('getGatingStatusFromJira suite', () => {
 		});
 
 		const mockResponse = { status: 200, text: mockText };
-		api.asApp().requestConnectedData = jest.fn().mockImplementation(() => ({
+		api.asApp().requestJira = jest.fn().mockImplementation(() => ({
 			then: (callback: any) => Promise.resolve(callback(mockResponse))
 		}));
 

--- a/app/src/jira-client/get-gating-status-from-jira.ts
+++ b/app/src/jira-client/get-gating-status-from-jira.ts
@@ -19,7 +19,7 @@ async function getGatingStatusFromJira(
 	}
 
 	// eslint-disable-next-line max-len
-	const getGatingStatusRoute = route`/rest/deployments/pipelines/${encodeURIComponent(pipelineId)}/environments/${encodeURIComponent(environmentId)}/deployments/${encodeURIComponent(deploymentId)}/gating-status`;
+	const getGatingStatusRoute = route`/rest/deployments/0.1/pipelines/${encodeURIComponent(pipelineId)}/environments/${encodeURIComponent(environmentId)}/deployments/${encodeURIComponent(deploymentId)}/gating-status`;
 
 	const apiResponse = await api
 		.asApp()

--- a/app/src/jira-client/get-gating-status-from-jira.ts
+++ b/app/src/jira-client/get-gating-status-from-jira.ts
@@ -19,7 +19,7 @@ async function getGatingStatusFromJira(
 	}
 
 	// eslint-disable-next-line max-len
-	const getGatingStatusRoute = route`/rest/deployments/${encodeURIComponent(cloudId)}/pipelines/${encodeURIComponent(pipelineId)}/environments/${encodeURIComponent(environmentId)}/deployments/${encodeURIComponent(deploymentId)}/gating-status`;
+	const getGatingStatusRoute = route`/rest/deployments/pipelines/${encodeURIComponent(pipelineId)}/environments/${encodeURIComponent(environmentId)}/deployments/${encodeURIComponent(deploymentId)}/gating-status`;
 
 	const apiResponse = await api
 		.asApp()

--- a/app/src/jira-client/get-gating-status-from-jira.ts
+++ b/app/src/jira-client/get-gating-status-from-jira.ts
@@ -19,11 +19,11 @@ async function getGatingStatusFromJira(
 	}
 
 	// eslint-disable-next-line max-len
-	const getGatingStatusRoute = route`/deployments/0.1/cloud/${encodeURIComponent(cloudId)}/pipelines/${encodeURIComponent(pipelineId)}/environments/${encodeURIComponent(environmentId)}/deployments/${encodeURIComponent(deploymentId)}/gating-status`;
+	const getGatingStatusRoute = route`/rest/deployments/${encodeURIComponent(cloudId)}/pipelines/${encodeURIComponent(pipelineId)}/environments/${encodeURIComponent(environmentId)}/deployments/${encodeURIComponent(deploymentId)}/gating-status`;
 
 	const apiResponse = await api
 		.asApp()
-		.requestConnectedData(getGatingStatusRoute, {
+		.requestJira(getGatingStatusRoute, {
 			method: 'GET',
 			headers: {
 				'content-type': 'application/json'

--- a/app/src/jira-client/send-event-to-jira.test.ts
+++ b/app/src/jira-client/send-event-to-jira.test.ts
@@ -7,7 +7,7 @@ import { InvalidPayloadError } from '../common/error';
 jest.mock('@forge/api', () => ({
 	...jest.requireActual('@forge/api'),
 	asApp: jest.fn().mockReturnValue({
-		requestConnectedData: jest.fn()
+		requestJira: jest.fn()
 	})
 }));
 
@@ -34,7 +34,7 @@ describe('Send event to Jira suite', () => {
 
 	it('Should return status with empty body if no responseString is returned', async () => {
 		const mockResponse = { status: 200, text: jest.fn() };
-		api.asApp().requestConnectedData = jest.fn().mockImplementation(() => ({
+		api.asApp().requestJira = jest.fn().mockImplementation(() => ({
 			then: (callback: any) => Promise.resolve(callback(mockResponse))
 		}));
 
@@ -61,7 +61,7 @@ describe('Send event to Jira suite', () => {
 			}));
 		});
 		const mockResponse = { status: 200, text: mockText };
-		api.asApp().requestConnectedData = jest.fn().mockImplementation(() => ({
+		api.asApp().requestJira = jest.fn().mockImplementation(() => ({
 			then: (callback: any) => Promise.resolve(callback(mockResponse))
 		}));
 

--- a/app/src/jira-client/send-event-to-jira.ts
+++ b/app/src/jira-client/send-event-to-jira.ts
@@ -34,7 +34,7 @@ async function invokeApi(
 ): Promise<JiraResponse> {
 	const apiResponse = await api
 		.asApp()
-		.requestConnectedData(sendEventToJiraRoute, {
+		.requestJira(sendEventToJiraRoute, {
 			method: 'POST',
 			headers: {
 				'content-type': 'application/json',
@@ -80,9 +80,9 @@ async function sendEventToJira(
 
 	switch (eventType) {
 		case EventType.BUILD:
-			return invokeApi(route`/builds/0.1/cloud/${cloudId}/bulk`, payload, logger);
+			return invokeApi(route`/rest/builds/0.1/bulk`, payload, logger);
 		case EventType.DEPLOYMENT:
-			return invokeApi(route`/deployments/0.1/cloud/${cloudId}/bulk`, payload, logger);
+			return invokeApi(route`/rest/deployments/0.1/bulk`, payload, logger);
 		default:
 			logger.error(Errors.INVALID_EVENT_TYPE);
 			throw new InvalidPayloadError(Errors.INVALID_EVENT_TYPE);


### PR DESCRIPTION
**What's in this PR?**
* Replaces usages of `requestConnectedData` with `requestJira`
* Replaces request paths to call data depot of format like `/deployments/0.1/cloud/${cloudId}/...` with format `/rest/deployments/0.1/...`

**Why**
`requestJira` is the way that Forge apps should be calling the data depot V1 APIs. This is now publicly documented ([see deployment info provider Forge manifest reference documentation](https://developer.atlassian.com/platform/forge/manifest-reference/modules/jira-software-deployment-info/)).

As this is an open-source Forge app which other Forge app developers may use as a reference, we want them to use `requestJira`.

Note that `requestJira` Forge function appends `ex/jira/{cloudId}` to the start of the request. This is why it doesn't need to be provided as a path param.

**Added feature flags**
?

**Affected issues**  
SUN-516

**How has this been tested?**  
Will soak in staging before merging this PR to main.

**What's Next?**